### PR TITLE
fix: Send course information when an student joins

### DIFF
--- a/docs/openapi/spec.openapi.yaml
+++ b/docs/openapi/spec.openapi.yaml
@@ -423,8 +423,16 @@ paths:
             example: "8_JI4bFA7"
           required: true
       responses:
-        "204": 
+        "200": 
           description: The student joined the course successfully. 
+          content: 
+            application/json: 
+              schema: 
+                type: object
+                properties: 
+                  course:
+                    allOf:
+                      - $ref: "#/components/schemas/public_course_fields"
         "400":
           description: The invitation code is not valid. 
           content:

--- a/src/courses/application/use_cases.go
+++ b/src/courses/application/use_cases.go
@@ -84,33 +84,33 @@ func (useCases *CoursesUseCases) SaveCourse(dto *dtos.CreateCourseDTO) (*entitie
 	return useCases.Repository.SaveCourse(dto)
 }
 
-func (useCases *CoursesUseCases) JoinCourseUsingInvitationCode(dto *dtos.JoinCourseUsingInvitationCodeDTO) error {
+func (useCases *CoursesUseCases) JoinCourseUsingInvitationCode(dto *dtos.JoinCourseUsingInvitationCodeDTO) (*entities.Course, error) {
 	// Get the course by the invitation code
 	course, err := useCases.Repository.GetCourseByInvitationCode(dto.InvitationCode)
 	if err != nil {
 		// Throw a domain error if no course with the given invitation code was found
 		if err == sql.ErrNoRows {
-			return errors.NoCourseWithInvitationCodeError{
+			return nil, errors.NoCourseWithInvitationCodeError{
 				Code: dto.InvitationCode,
 			}
 		}
 
-		return err
+		return nil, err
 	}
 
 	// Check if the student is already in the course
 	isStudentInCourse, err := useCases.Repository.IsStudentInCourse(dto.StudentUUID, course.UUID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if isStudentInCourse {
-		return errors.StudentAlreadyInCourse{
+		return nil, errors.StudentAlreadyInCourse{
 			CourseName: course.Name,
 		}
 	}
 
 	err = useCases.Repository.AddStudentToCourse(dto.StudentUUID, course.UUID)
-	return err
+	return course, err
 }
 
 func (useCases *CoursesUseCases) GetEnrolledCourses(userUUID string) (*dtos.EnrolledCoursesDto, error) {

--- a/src/courses/infrastructure/http/http_controllers.go
+++ b/src/courses/infrastructure/http/http_controllers.go
@@ -102,7 +102,7 @@ func (controller *CoursesController) HandleJoinCourse(c *gin.Context) {
 	}
 
 	// Join course
-	err := controller.UseCases.JoinCourseUsingInvitationCode(&dtos.JoinCourseUsingInvitationCodeDTO{
+	course, err := controller.UseCases.JoinCourseUsingInvitationCode(&dtos.JoinCourseUsingInvitationCodeDTO{
 		StudentUUID:    studentUUID,
 		InvitationCode: invitationCode,
 	})
@@ -111,7 +111,13 @@ func (controller *CoursesController) HandleJoinCourse(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusNoContent, nil)
+	c.JSON(http.StatusOK, gin.H{
+		"course": gin.H{
+			"uuid":  course.UUID,
+			"name":  course.Name,
+			"color": course.Color,
+		},
+	})
 }
 
 func (controller *CoursesController) HandleGetEnrolledCourses(c *gin.Context) {


### PR DESCRIPTION
## Includes 📋

- Return course information needed by the client when an student joins a course using an invitation code. 

## Related Issues 🔎

Fixes #57 

<!-- 
## Notes 📝

Additional notes or implementation details. -->
