### PR TITLE
fix: Save who created admin and teacher accounts

### DIFF
--- a/sql/migrations/20230920232901_init.down.sql
+++ b/sql/migrations/20230920232901_init.down.sql
@@ -1,3 +1,7 @@
+-- ## Triggers
+DROP TRIGGER IF EXISTS set_created_by ON users;
+DROP FUNCTION IF EXISTS update_created_by();
+
 -- ## Indexes
 DROP INDEX IF EXISTS idx_class_users;
 
@@ -11,6 +15,10 @@ DROP INDEX IF EXISTS idx_users_fullname;
 
 -- ## Views
 DROP VIEW IF EXISTS courses_with_color;
+
+DROP VIEW IF EXISTS courses_has_users_with_course;
+
+DROP VIEW IF EXISTS users_with_creator;
 
 -- ## Tables
 DROP TABLE IF EXISTS grade_has_criteria;
@@ -50,3 +58,4 @@ DROP TYPE IF EXISTS USER_ROLES;
 
 -- ## Extensions
 DROP EXTENSION IF EXISTS "uuid-ossp";
+DROP EXTENSION IF EXISTS "citext";

--- a/src/accounts/domain/dtos/register_user_dto.go
+++ b/src/accounts/domain/dtos/register_user_dto.go
@@ -5,4 +5,5 @@ type RegisterUserDTO struct {
 	Email           string
 	InstitutionalId string
 	Password        string
+	CreatedBy       string
 }

--- a/src/accounts/domain/entities/user.go
+++ b/src/accounts/domain/entities/user.go
@@ -8,4 +8,5 @@ type User struct {
 	InstitutionalId string
 	PasswordHash    string
 	CreatedAt       string
+	CreatedBy       string
 }

--- a/src/accounts/infrastructure/http/http_controllers.go
+++ b/src/accounts/infrastructure/http/http_controllers.go
@@ -42,6 +42,8 @@ func (controller *AccountsController) HandleRegisterStudent(c *gin.Context) {
 }
 
 func (controller *AccountsController) HandleRegisterAdmin(c *gin.Context) {
+	adminUUID := c.GetString("session_uuid")
+
 	// Parse request body
 	var request requests.RegisterAdminRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
@@ -62,6 +64,7 @@ func (controller *AccountsController) HandleRegisterAdmin(c *gin.Context) {
 
 	// Register admin
 	dto := request.ToDTO()
+	dto.CreatedBy = adminUUID
 	err := controller.UseCases.RegisterAdmin(*dto)
 	if err != nil {
 		c.Error(err)
@@ -72,6 +75,8 @@ func (controller *AccountsController) HandleRegisterAdmin(c *gin.Context) {
 }
 
 func (controller *AccountsController) HandleRegisterTeacher(c *gin.Context) {
+	adminUUID := c.GetString("session_uuid")
+
 	// Parse request body
 	var request requests.RegisterTeacherRequest
 	if err := c.ShouldBindJSON(&request); err != nil {
@@ -92,6 +97,7 @@ func (controller *AccountsController) HandleRegisterTeacher(c *gin.Context) {
 
 	// Register teacher
 	dto := request.ToDTO()
+	dto.CreatedBy = adminUUID
 	err := controller.UseCases.RegisterTeacher(*dto)
 	if err != nil {
 		c.Error(err)
@@ -114,6 +120,7 @@ func (controller *AccountsController) HandleGetAdmins(c *gin.Context) {
 			"uuid":       admin.UUID,
 			"full_name":  admin.FullName,
 			"created_at": admin.CreatedAt,
+			"created_by": admin.CreatedBy,
 		}
 	}
 

--- a/src/accounts/infrastructure/implementations/accounts_repository_impl.go
+++ b/src/accounts/infrastructure/implementations/accounts_repository_impl.go
@@ -58,8 +58,8 @@ func (repository *AccountsPostgresRepository) SaveAdmin(dto dtos.RegisterUserDTO
 	defer cancel()
 
 	query := `
-		INSERT INTO users (role, email, full_name, password_hash)
-		VALUES ($1, $2, $3, $4)
+		INSERT INTO users (role, email, full_name, password_hash, created_by)
+		VALUES ($1, $2, $3, $4, $5)
 	`
 
 	_, err := repository.Connection.ExecContext(
@@ -69,6 +69,7 @@ func (repository *AccountsPostgresRepository) SaveAdmin(dto dtos.RegisterUserDTO
 		dto.Email,
 		dto.FullName,
 		dto.Password,
+		dto.CreatedBy,
 	)
 	if err != nil {
 		return err
@@ -83,8 +84,8 @@ func (repository *AccountsPostgresRepository) SaveTeacher(dto dtos.RegisterUserD
 	defer cancel()
 
 	query := `
-		INSERT INTO users (role, email, full_name, password_hash)
-		VALUES ($1, $2, $3, $4)
+		INSERT INTO users (role, email, full_name, password_hash, created_by)
+		VALUES ($1, $2, $3, $4, $5)
 	`
 
 	_, err := repository.Connection.ExecContext(
@@ -94,6 +95,7 @@ func (repository *AccountsPostgresRepository) SaveTeacher(dto dtos.RegisterUserD
 		dto.Email,
 		dto.FullName,
 		dto.Password,
+		dto.CreatedBy,
 	)
 	if err != nil {
 		return err
@@ -221,8 +223,8 @@ func (repository *AccountsPostgresRepository) GetAdmins() ([]*entities.User, err
 	defer cancel()
 
 	query := `
-		SELECT id, institutional_id, email, full_name, created_at
-		FROM users
+		SELECT id, institutional_id, email, full_name, created_at, creator_full_name
+		FROM users_with_creator
 		WHERE role = 'admin'
 	`
 
@@ -241,6 +243,7 @@ func (repository *AccountsPostgresRepository) GetAdmins() ([]*entities.User, err
 			&admin.Email,
 			&admin.FullName,
 			&admin.CreatedAt,
+			&admin.CreatedBy,
 		)
 
 		if err != nil {


### PR DESCRIPTION
## Includes 📋

- Add new field in users table
- Create a view to join the creator fullname
- Update repository queries 

## Related Issues 🔎

Fixes #61 


## Notes 📝

- By default, the new user UUID is saved as the account creator, so, **it's needed to explicitly define the creator UUID in the queries to save the admins and teachers account**.
