### PR TITLE
feat: Add criteria to rubric objective

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,6 @@ delete_pakage:
 	rm -rf src/$$name; 
 	
 coverage:
+	go clean -testcache; \
 	go test -coverpkg ./... -coverprofile coverage.txt __tests__/integration/*.go; \
 	go tool cover -html=coverage.txt -o coverage.html; 

--- a/__tests__/integration/main_test.go
+++ b/__tests__/integration/main_test.go
@@ -26,6 +26,9 @@ var (
 
 	registeredTeacherEmail string
 	registeredTeacherPass  string
+
+	secondRegisteredTeacherEmail string
+	secondRegisteredTeacherPass  string
 )
 
 type GenericTestCase struct {
@@ -59,7 +62,7 @@ func setupRouter() {
 
 func registerBaseAccounts() {
 	registerBaseStudent()
-	registerBaseTeacher()
+	registerBaseTeachers()
 }
 
 func registerBaseStudent() {
@@ -80,7 +83,8 @@ func registerBaseStudent() {
 	registeredStudentPass = studentPassword
 }
 
-func registerBaseTeacher() {
+func registerBaseTeachers() {
+	// Register the first teacher
 	teacherEmail := "judy.arroyo.2020@upb.edu.co"
 	teacherPassword := "judy/password/2023"
 
@@ -95,6 +99,22 @@ func registerBaseTeacher() {
 
 	registeredTeacherEmail = teacherEmail
 	registeredTeacherPass = teacherPassword
+
+	// Register the second teacher
+	secondTeacherEmail := "trofim.vijay.2020@upb.edu.co"
+	secondTeacherPassword := "trofim/password/2023"
+
+	code = RegisterTeacherAccount(requests.RegisterTeacherRequest{
+		FullName: "Trofim Vijay",
+		Email:    secondTeacherEmail,
+		Password: secondTeacherPassword,
+	})
+	if code != http.StatusCreated {
+		panic("Error registering base teacher")
+	}
+
+	secondRegisteredTeacherEmail = secondTeacherEmail
+	secondRegisteredTeacherPass = secondTeacherPassword
 }
 
 // --- Helpers ---

--- a/docs/openapi/spec.openapi.yaml
+++ b/docs/openapi/spec.openapi.yaml
@@ -1286,7 +1286,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/default_error_response"
 
-  /rubrics/{objective_uuid}/criteria:
+  /rubrics/objectives/{objective_uuid}/criteria:
     post:
       tags:
         - Rubrics
@@ -1498,7 +1498,7 @@ components:
         description:
           type: string
           example: "Se evidencia desarrollo de, al menos, el 75% de los métodos solicitados para la estructura de datos planteada"
-        grade:
+        weight:
           type: number
           example: 0.20
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/bytedance/sonic v1.10.2 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
@@ -38,7 +38,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/arch v0.5.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/net v0.16.0 // indirect
+	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
+github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
+github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/cors v1.4.0 h1:oJ6gwtUl3lqV0WEIwM/LxPF1QZ5qe2lGWdY2+bz7y0g=
 github.com/gin-contrib/cors v1.4.0/go.mod h1:bs9pNM0x/UsmHPBWT2xZz9ROh8xYjYkiURUfmBoMlcs=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
@@ -188,6 +190,8 @@ golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
 golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/net v0.16.0 h1:7eBu7KsSvFDtSXUIDbh3aqlK4DPsZ1rByC8PFfBThos=
 golang.org/x/net v0.16.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/sql/migrations/20230920232901_init.down.sql
+++ b/sql/migrations/20230920232901_init.down.sql
@@ -22,6 +22,8 @@ DROP VIEW IF EXISTS courses_has_users_view;
 
 DROP VIEW IF EXISTS users_with_creator;
 
+DROP VIEW IF EXISTS criteria_objectives_owners;
+
 -- ## Tables
 DROP TABLE IF EXISTS grade_has_criteria;
 

--- a/sql/migrations/20230920232901_init.down.sql
+++ b/sql/migrations/20230920232901_init.down.sql
@@ -22,7 +22,9 @@ DROP VIEW IF EXISTS courses_has_users_view;
 
 DROP VIEW IF EXISTS users_with_creator;
 
-DROP VIEW IF EXISTS criteria_objectives_owners;
+DROP VIEW IF EXISTS objectives_owners;
+
+DROP VIEW IF EXISTS criteria_owners;
 
 -- ## Tables
 DROP TABLE IF EXISTS grade_has_criteria;

--- a/sql/migrations/20230920232901_init.up.sql
+++ b/sql/migrations/20230920232901_init.up.sql
@@ -183,13 +183,21 @@ FROM
   INNER JOIN courses ON courses_has_users.course_id = courses.id
   INNER JOIN colors ON courses.color_id = colors.id;
 
+--- ### Objectives
+CREATE
+OR REPLACE VIEW objectives_owners AS
+SELECT
+  objectives.id AS objective_id,
+  rubrics.teacher_id
+FROM
+  objectives
+  INNER JOIN rubrics ON objectives.rubric_id = rubrics.id;
+
 --- ### Criteria
 CREATE
-OR REPLACE VIEW criteria_objectives_owners AS
+OR REPLACE VIEW criteria_owners AS
 SELECT
   criteria.id AS criteria_id,
-  criteria.objective_id,
-  objectives.rubric_id,
   rubrics.teacher_id
 FROM
   criteria

--- a/sql/migrations/20230920232901_init.up.sql
+++ b/sql/migrations/20230920232901_init.up.sql
@@ -183,6 +183,19 @@ FROM
   INNER JOIN courses ON courses_has_users.course_id = courses.id
   INNER JOIN colors ON courses.color_id = colors.id;
 
+--- ### Criteria
+CREATE
+OR REPLACE VIEW criteria_objectives_owners AS
+SELECT
+  criteria.id AS criteria_id,
+  criteria.objective_id,
+  objectives.rubric_id,
+  rubrics.teacher_id
+FROM
+  criteria
+  INNER JOIN objectives ON criteria.objective_id = objectives.id
+  INNER JOIN rubrics ON objectives.rubric_id = rubrics.id;
+
 -- ## Triggers
 --- ### Update created_by on users
 CREATE

--- a/sql/migrations/20230920232901_init.up.sql
+++ b/sql/migrations/20230920232901_init.up.sql
@@ -54,14 +54,16 @@ CREATE TABLE IF NOT EXISTS rubrics (
 CREATE TABLE IF NOT EXISTS objectives (
   "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   "rubric_id" UUID NOT NULL REFERENCES rubrics(id),
-  "description" VARCHAR(510) NOT NULL
+  "description" VARCHAR(510) NOT NULL, 
+  "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS criteria (
   "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   "objective_id" UUID NOT NULL REFERENCES objectives(id),
   "description" VARCHAR(510) NOT NULL,
-  "weight" DECIMAL(5, 2) NOT NULL
+  "weight" DECIMAL(5, 2) NOT NULL,
+  "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS laboratories (

--- a/src/rubrics/application/use_cases.go
+++ b/src/rubrics/application/use_cases.go
@@ -45,14 +45,12 @@ func (useCases *RubricsUseCases) GetRubricByUUID(dto *dtos.GetRubricDto) (rubric
 }
 
 func (useCases *RubricsUseCases) AddObjectiveToRubric(dto *dtos.AddObjectiveToRubricDTO) (objectiveUUID string, err error) {
-	// Get the rubric
-	rubric, err := useCases.RubricsRepository.GetByUUID(dto.RubricUUID)
+	// Check if the rubric belongs to the teacher
+	teacherOwnsRubric, err := useCases.RubricsRepository.DoesTeacherOwnRubric(dto.TeacherUUID, dto.RubricUUID)
 	if err != nil {
 		return "", err
 	}
-
-	// Check if the rubric belongs to the teacher
-	if rubric.TeacherUUID != dto.TeacherUUID {
+	if !teacherOwnsRubric {
 		return "", &errors.TeacherDoesNotOwnsRubric{}
 	}
 
@@ -63,4 +61,23 @@ func (useCases *RubricsUseCases) AddObjectiveToRubric(dto *dtos.AddObjectiveToRu
 	}
 
 	return objectiveUUID, nil
+}
+
+func (useCases *RubricsUseCases) AddCriteriaToObjective(dto *dtos.AddCriteriaToObjectiveDTO) (criteriaUUID string, err error) {
+	// Check if the objective belongs to a rubric that belongs to the teacher
+	teacherOwnsObjective, err := useCases.RubricsRepository.DoesTeacherOwnObjective(dto.TeacherUUID, dto.ObjectiveUUID)
+	if err != nil {
+		return "", err
+	}
+	if !teacherOwnsObjective {
+		return "", &errors.TeacherDoesNotOwnsRubric{}
+	}
+
+	// Add the criteria
+	criteriaUUID, err = useCases.RubricsRepository.AddCriteriaToObjective(dto)
+	if err != nil {
+		return "", err
+	}
+
+	return criteriaUUID, nil
 }

--- a/src/rubrics/domain/definitions/rubrics_repository.go
+++ b/src/rubrics/domain/definitions/rubrics_repository.go
@@ -10,5 +10,10 @@ type RubricsRepository interface {
 	GetByUUID(uuid string) (rubric *entities.Rubric, err error)
 	GetAllCreatedByTeacher(teacherUUID string) (rubrics []*dtos.CreatedRubricDTO, err error)
 
+	DoesTeacherOwnRubric(teacherUUID string, rubricUUID string) (bool, error)
+	DoesTeacherOwnObjective(teacherUUID string, objectiveUUID string) (bool, error)
+	DoesTeacherOwnCriteria(teacherUUID string, criteriaUUID string) (bool, error)
+
 	AddObjectiveToRubric(rubricUUID string, objectiveDescription string) (objectiveUUID string, err error)
+	AddCriteriaToObjective(dto *dtos.AddCriteriaToObjectiveDTO) (criteriaUUID string, err error)
 }

--- a/src/rubrics/domain/dtos/add_criteria_to_objective_dto.go
+++ b/src/rubrics/domain/dtos/add_criteria_to_objective_dto.go
@@ -1,0 +1,8 @@
+package dtos
+
+type AddCriteriaToObjectiveDTO struct {
+	TeacherUUID         string
+	ObjectiveUUID       string
+	CriteriaDescription string
+	CriteriaWeight      float64
+}

--- a/src/rubrics/domain/errors/criteria_not_found_error.go
+++ b/src/rubrics/domain/errors/criteria_not_found_error.go
@@ -1,0 +1,13 @@
+package errors
+
+import "net/http"
+
+type CriteriaNotFoundError struct{}
+
+func (err *CriteriaNotFoundError) Error() string {
+	return "Rubric criteria not found"
+}
+
+func (err *CriteriaNotFoundError) StatusCode() int {
+	return http.StatusNotFound
+}

--- a/src/rubrics/domain/errors/objective_not_found_error.go
+++ b/src/rubrics/domain/errors/objective_not_found_error.go
@@ -1,0 +1,13 @@
+package errors
+
+import "net/http"
+
+type ObjectiveNotFoundError struct{}
+
+func (err *ObjectiveNotFoundError) Error() string {
+	return "Rubric objective not found"
+}
+
+func (err *ObjectiveNotFoundError) StatusCode() int {
+	return http.StatusNotFound
+}

--- a/src/rubrics/infrastructure/http/http_routes.go
+++ b/src/rubrics/infrastructure/http/http_routes.go
@@ -45,4 +45,11 @@ func StartRubricsRoutes(g *gin.RouterGroup) {
 		shared_infrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
 		controller.HandleAddObjectiveToRubric,
 	)
+
+	rubricsGroup.POST(
+		"/objectives/:objectiveUUID/criteria",
+		shared_infrastructure.WithAuthenticationMiddleware(),
+		shared_infrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
+		controller.HandleAddCriteriaToObjective,
+	)
 }

--- a/src/rubrics/infrastructure/implementations/rubrics_repository.go
+++ b/src/rubrics/infrastructure/implementations/rubrics_repository.go
@@ -198,7 +198,7 @@ func (repository *RubricsPostgresRepository) DoesTeacherOwnObjective(teacherUUID
 	// Get the objective
 	row := repository.Connection.QueryRowContext(ctx, `
 		SELECT teacher_id
-		FROM criteria_objectives_owners
+		FROM objectives_owners
 		WHERE objective_id = $1
 	`, objectiveUUID)
 
@@ -222,7 +222,7 @@ func (repository *RubricsPostgresRepository) DoesTeacherOwnCriteria(teacherUUID 
 	// Get the criteria
 	row := repository.Connection.QueryRowContext(ctx, `
 		SELECT teacher_id
-		FROM criteria_objectives_owners
+		FROM criteria_owners
 		WHERE criteria_id = $1
 	`, criteriaUUID)
 

--- a/src/rubrics/infrastructure/implementations/rubrics_repository.go
+++ b/src/rubrics/infrastructure/implementations/rubrics_repository.go
@@ -116,6 +116,7 @@ func (repository *RubricsPostgresRepository) GetByUUID(uuid string) (rubric *ent
 		SELECT id, rubric_id, description
 		FROM objectives
 		WHERE rubric_id = $1
+		ORDER BY created_at ASC
 	`, uuid)
 	if err != nil {
 		return nil, err
@@ -143,6 +144,7 @@ func (repository *RubricsPostgresRepository) GetByUUID(uuid string) (rubric *ent
 		SELECT id, objective_id, description, weight
 		FROM criteria
 		WHERE objective_id = ANY($1)
+		ORDER BY created_at ASC
 	`, pq.Array(objectivesUUIDs))
 	if err != nil {
 		return nil, err

--- a/src/rubrics/infrastructure/requests/add_criteria_to_objective_request.go
+++ b/src/rubrics/infrastructure/requests/add_criteria_to_objective_request.go
@@ -1,0 +1,6 @@
+package requests
+
+type AddCriteriaToObjectiveRequest struct {
+	Description string  `json:"description" validate:"required,min=8,max=510"`
+	Weight      float64 `json:"weight" validate:"required,numeric,min=0,max=100"`
+}


### PR DESCRIPTION
## Includes 📋

- Create new `objectives_owners` and `criteria_owners` view to ease the objectives and rubric ownership validation. 
- Add `created_at` field to objectives and rubrics table
- Endpoint to add criteria to an objective
- Tests for the new endpoint
- Bump dependencies

## Related Issues 🔎

Closes #77 

<!-- 
## Notes 📝
Additional notes or implementation details.
-->
