### PR TITLE
feat: Update laboratory by UUID

### DIFF
--- a/docs/bruno/laboratories/update-laboratory.bru
+++ b/docs/bruno/laboratories/update-laboratory.bru
@@ -1,0 +1,20 @@
+meta {
+  name: update-laboratory
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{BASE_URL}}/laboratories/a9be2f1e-e0e9-4b8d-9f72-6ed55ea5b1b8
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "Binary Tree", 
+    "opening_date": "2023-12-01T12:00", 
+    "due_date": "2023-12-02T00:00",
+    "rubric_uuid": null
+  }
+}

--- a/docs/openapi/spec.openapi.yaml
+++ b/docs/openapi/spec.openapi.yaml
@@ -977,42 +977,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/default_error_response"
 
-  /laboratories/{laboratory_uuid}/rubric:
-    patch:
-      tags:
-        - Laboratories
-      security:
-        - cookieAuth: []
-      description: Add a rubric to the given laboratory.
-      parameters:
-        - in: path
-          name: laboratory_uuid
-          schema:
-            type: string
-            example: "e6341b0d-e959-4081-b30a-38b5beb31096"
-          required: true
-      responses:
-        "204":
-          description: The rubric was added to the given laboratory
-        "400":
-          description: Required fields were missed or doesn't fulfill the required format.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/default_error_response"
-        "403":
-          description: The session token isn't valid or the user doesn't have enough permissions.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/default_error_response"
-        "500":
-          description: There was an unexpected error in the server side.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/default_error_response"
-
   # Blocks
   /markdown_blocks/{block_uuid}:
     delete:
@@ -1630,6 +1594,9 @@ components:
         closing_date:
           type: string
           example: "2023-12-02T00:00"
+        rubric_uuid: 
+          type: string
+          example: "3fc29baf-9517-430c-9048-0f85599b61b7"
 
     create_test_block_req:
       type: object

--- a/src/laboratories/application/use_cases.go
+++ b/src/laboratories/application/use_cases.go
@@ -6,11 +6,14 @@ import (
 	"github.com/UPB-Code-Labs/main-api/src/laboratories/domain/definitions"
 	"github.com/UPB-Code-Labs/main-api/src/laboratories/domain/dtos"
 	"github.com/UPB-Code-Labs/main-api/src/laboratories/domain/entities"
+	rubrics_definitions "github.com/UPB-Code-Labs/main-api/src/rubrics/domain/definitions"
+	rubrics_errors "github.com/UPB-Code-Labs/main-api/src/rubrics/domain/errors"
 )
 
 type LaboratoriesUseCases struct {
 	LaboratoriesRepository definitions.LaboratoriesRepository
 	CoursesRepository      courses_definitions.CoursesRepository
+	RubricsRepository      rubrics_definitions.RubricsRepository
 }
 
 func (useCases *LaboratoriesUseCases) CreateLaboratory(dto *dtos.CreateLaboratoryDTO) (laboratory *entities.Laboratory, err error) {
@@ -24,5 +27,36 @@ func (useCases *LaboratoriesUseCases) CreateLaboratory(dto *dtos.CreateLaborator
 		return nil, courses_errors.TeacherDoesNotOwnsCourseError{}
 	}
 
+	// Create the laboratory
 	return useCases.LaboratoriesRepository.SaveLaboratory(dto)
+}
+
+func (useCases *LaboratoriesUseCases) UpdateLaboratory(dto *dtos.UpdateLaboratoryDTO) error {
+	// Check that the teacher owns the laboratory / course
+	laboratory, err := useCases.LaboratoriesRepository.GetLaboratoryByUUID(dto.LaboratoryUUID)
+	if err != nil {
+		return err
+	}
+
+	teacherOwnsCourse, err := useCases.CoursesRepository.DoesTeacherOwnsCourse(dto.TeacherUUID, laboratory.CourseUUID)
+	if err != nil {
+		return err
+	}
+	if !teacherOwnsCourse {
+		return courses_errors.TeacherDoesNotOwnsCourseError{}
+	}
+
+	// Check that the teacher owns the rubric
+	if dto.RubricUUID != nil {
+		teacherOwnsRubric, err := useCases.RubricsRepository.DoesTeacherOwnRubric(dto.TeacherUUID, *dto.RubricUUID)
+		if err != nil {
+			return err
+		}
+		if !teacherOwnsRubric {
+			return &rubrics_errors.TeacherDoesNotOwnsRubric{}
+		}
+	}
+
+	// Update the laboratory
+	return useCases.LaboratoriesRepository.UpdateLaboratory(dto)
 }

--- a/src/laboratories/domain/definitions/laboratories_repository.go
+++ b/src/laboratories/domain/definitions/laboratories_repository.go
@@ -8,4 +8,5 @@ import (
 type LaboratoriesRepository interface {
 	GetLaboratoryByUUID(uuid string) (laboratory *entities.Laboratory, err error)
 	SaveLaboratory(dto *dtos.CreateLaboratoryDTO) (laboratory *entities.Laboratory, err error)
+	UpdateLaboratory(dto *dtos.UpdateLaboratoryDTO) error
 }

--- a/src/laboratories/domain/dtos/laboratories_dtos.go
+++ b/src/laboratories/domain/dtos/laboratories_dtos.go
@@ -7,3 +7,12 @@ type CreateLaboratoryDTO struct {
 	OpeningDate string
 	DueDate     string
 }
+
+type UpdateLaboratoryDTO struct {
+	LaboratoryUUID string
+	TeacherUUID    string
+	RubricUUID     *string
+	Name           string
+	OpeningDate    string
+	DueDate        string
+}

--- a/src/laboratories/infrastructure/http/controllers.go
+++ b/src/laboratories/infrastructure/http/controllers.go
@@ -63,3 +63,61 @@ func (controller *LaboratoriesController) CreateLaboratory(c *gin.Context) {
 		"uuid": laboratory.UUID,
 	})
 }
+
+func (controller *LaboratoriesController) UpdateLaboratory(c *gin.Context) {
+	teacherUUID := c.GetString("session_uuid")
+	laboratoryUUID := c.Param("laboratory_uuid")
+
+	// Validate the laboratory UUID
+	if err := infrastructure.GetValidator().Var(laboratoryUUID, "uuid4"); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Laboratory UUID is not valid",
+		})
+		return
+	}
+
+	// Parse request body
+	var request requests.UpdateLaboratoryRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Request body is not valid",
+		})
+		return
+	}
+
+	// Validate request body
+	if err := infrastructure.GetValidator().Struct(request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Validation error",
+			"errors":  err.Error(),
+		})
+		return
+	}
+
+	// Validate due date is after opening date
+	openingDate, err1 := infrastructure.ParseISODate(request.OpeningDate)
+	dueDate, err2 := infrastructure.ParseISODate(request.DueDate)
+	if err1 != nil || err2 != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Invalid date format",
+		})
+		return
+	}
+
+	if dueDate.Before(openingDate) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Due date must be after opening date",
+		})
+		return
+	}
+
+	// Update laboratory
+	dto := request.ToDTO(laboratoryUUID, teacherUUID)
+	err := controller.UseCases.UpdateLaboratory(dto)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/src/laboratories/infrastructure/http/routes.go
+++ b/src/laboratories/infrastructure/http/routes.go
@@ -4,6 +4,7 @@ import (
 	courses_implementation "github.com/UPB-Code-Labs/main-api/src/courses/infrastructure/implementations"
 	"github.com/UPB-Code-Labs/main-api/src/laboratories/application"
 	"github.com/UPB-Code-Labs/main-api/src/laboratories/infrastructure/implementations"
+	rubrics_implementation "github.com/UPB-Code-Labs/main-api/src/rubrics/infrastructure/implementations"
 	"github.com/UPB-Code-Labs/main-api/src/shared/infrastructure"
 	"github.com/gin-gonic/gin"
 )
@@ -14,6 +15,7 @@ func StartLaboratoriesRoutes(g *gin.RouterGroup) {
 	useCases := application.LaboratoriesUseCases{
 		LaboratoriesRepository: implementations.GetLaboratoriesPostgresRepositoryInstance(),
 		CoursesRepository:      courses_implementation.GetCoursesPgRepository(),
+		RubricsRepository:      rubrics_implementation.GetRubricsPgRepository(),
 	}
 
 	controller := LaboratoriesController{
@@ -21,4 +23,5 @@ func StartLaboratoriesRoutes(g *gin.RouterGroup) {
 	}
 
 	laboratoriesGroup.POST("", infrastructure.WithAuthenticationMiddleware(), infrastructure.WithAuthorizationMiddleware([]string{"teacher"}), controller.CreateLaboratory)
+	laboratoriesGroup.PUT("/:laboratory_uuid", infrastructure.WithAuthenticationMiddleware(), infrastructure.WithAuthorizationMiddleware([]string{"teacher"}), controller.UpdateLaboratory)
 }

--- a/src/laboratories/infrastructure/implementations/laboratories_respository.go
+++ b/src/laboratories/infrastructure/implementations/laboratories_respository.go
@@ -143,3 +143,17 @@ func (repository *LaboratoriesPostgresRepository) SaveLaboratory(dto *dtos.Creat
 
 	return repository.GetLaboratoryByUUID(laboratoryUUID)
 }
+
+func (repository *LaboratoriesPostgresRepository) UpdateLaboratory(dto *dtos.UpdateLaboratoryDTO) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	query := `
+		UPDATE laboratories
+		SET name = $1, opening_date = $2, due_date = $3, rubric_id = $4
+		WHERE id = $5
+	`
+
+	_, err := repository.Connection.ExecContext(ctx, query, dto.Name, dto.OpeningDate, dto.DueDate, dto.RubricUUID, dto.LaboratoryUUID)
+	return err
+}

--- a/src/laboratories/infrastructure/requests/laboratories_requests.go
+++ b/src/laboratories/infrastructure/requests/laboratories_requests.go
@@ -18,3 +18,21 @@ func (request *CreateLaboratoryRequest) ToDTO(teacherUUID string) *dtos.CreateLa
 		DueDate:     request.DueDate,
 	}
 }
+
+type UpdateLaboratoryRequest struct {
+	Name        string  `json:"name" validate:"required,min=4,max=255"`
+	OpeningDate string  `json:"opening_date" validate:"required,ISO_date"`
+	DueDate     string  `json:"due_date" validate:"required,ISO_date"`
+	RubricUUID  *string `json:"rubric_uuid,omitempty" validate:"omitempty,uuid4"`
+}
+
+func (request *UpdateLaboratoryRequest) ToDTO(laboratoryUUID string, teacherUUID string) *dtos.UpdateLaboratoryDTO {
+	return &dtos.UpdateLaboratoryDTO{
+		TeacherUUID:    teacherUUID,
+		LaboratoryUUID: laboratoryUUID,
+		RubricUUID:     request.RubricUUID,
+		Name:           request.Name,
+		OpeningDate:    request.OpeningDate,
+		DueDate:        request.DueDate,
+	}
+}


### PR DESCRIPTION
## Includes 📋

- Update laboratory by UUID. 

## Related Issues 🔎

Completes #104 without tests.

## Notes 📝

- This endpoint is meant to be used to update the laboratory details such as its name or open / due date and assign a rubric to the laboratory. 
- Test will be added among with the endpoint to get a laboratory by its UUID :exclamation: 
