### PR TITLE
feat: Update test block

### DIFF
--- a/__tests__/integration/blocks_test.go
+++ b/__tests__/integration/blocks_test.go
@@ -67,3 +67,78 @@ func TestUpdateMarkdownBlockContent(t *testing.T) {
 	block := response["markdown_blocks"].([]interface{})[0].(map[string]interface{})
 	c.Equal("# Updated main title", block["content"].(string))
 }
+
+func TestUpdateTestBlock(t *testing.T) {
+	c := require.New(t)
+
+	// Login as a teacher
+	w, r := PrepareRequest("POST", "/api/v1/session/login", map[string]interface{}{
+		"email":    registeredTeacherEmail,
+		"password": registeredTeacherPass,
+	})
+	router.ServeHTTP(w, r)
+	cookie := w.Result().Cookies()[0]
+
+	// Create a course
+	courseUUID, status := CreateCourse("Update test block test - course")
+	c.Equal(http.StatusCreated, status)
+
+	// Create a laboratory
+	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
+		"name":         "Update test block test - laboratory",
+		"course_uuid":  courseUUID,
+		"opening_date": "2023-12-01T08:00",
+		"due_date":     "3023-12-01T00:00",
+	})
+	c.Equal(http.StatusCreated, status)
+	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
+
+	// Get the supported languages
+	languagesResponse, status := GetSupportedLanguages(cookie)
+	c.Equal(http.StatusOK, status)
+
+	languages := languagesResponse["languages"].([]interface{})
+	c.Greater(len(languages), 0)
+
+	firstLanguage := languages[0].(map[string]interface{})
+	firstLanguageUUID := firstLanguage["uuid"].(string)
+
+	// Create a test block
+	zipFile, err := GetSampleTestsArchive()
+	c.Nil(err)
+
+	blockCreationResponse, status := CreateTestBlock(&CreateTestBlockUtilsDTO{
+		laboratoryUUID: laboratoryUUID,
+		languageUUID:   firstLanguageUUID,
+		blockName:      "Update test block test - block",
+		cookie:         cookie,
+		testFile:       zipFile,
+	})
+	c.Equal(http.StatusCreated, status)
+	testBlockUUID := blockCreationResponse["uuid"].(string)
+
+	// Update the test block
+	newName := "Update test block test - block - updated"
+	zipFile, err = GetSampleTestsArchive()
+	c.Nil(err)
+
+	_, status = UpdateTestBlock(&UpdateTestBlockUtilsDTO{
+		blockUUID:    testBlockUUID,
+		languageUUID: firstLanguageUUID,
+		blockName:    newName,
+		cookie:       cookie,
+		testFile:     zipFile,
+	})
+	c.Equal(http.StatusNoContent, status)
+
+	// Check that the test block data was updated
+	laboratoryResponse, status := GetLaboratoryByUUID(cookie, laboratoryUUID)
+	c.Equal(http.StatusOK, status)
+
+	blocks := laboratoryResponse["test_blocks"].([]interface{})
+	c.Equal(1, len(blocks))
+
+	block := blocks[0].(map[string]interface{})
+	c.Equal(newName, block["name"].(string))
+	c.Equal(firstLanguageUUID, block["language_uuid"].(string))
+}

--- a/__tests__/integration/blocks_utils_test.go
+++ b/__tests__/integration/blocks_utils_test.go
@@ -1,8 +1,13 @@
 package integration
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
+	"os"
 )
 
 func UpdateMarkdownBlockContent(cookie *http.Cookie, blockUUID string, payload map[string]interface{}) (response map[string]interface{}, statusCode int) {
@@ -11,6 +16,61 @@ func UpdateMarkdownBlockContent(cookie *http.Cookie, blockUUID string, payload m
 	r.AddCookie(cookie)
 	router.ServeHTTP(w, r)
 
+	jsonResponse := ParseJsonResponse(w.Body)
+	return jsonResponse, w.Code
+}
+
+type UpdateTestBlockUtilsDTO struct {
+	blockUUID    string
+	languageUUID string
+	blockName    string
+	cookie       *http.Cookie
+	testFile     *os.File
+}
+
+func UpdateTestBlock(dto *UpdateTestBlockUtilsDTO) (response map[string]interface{}, statusCode int) {
+	// Create the request body
+	var body bytes.Buffer
+
+	// Create the multipart form
+	writer := multipart.NewWriter(&body)
+
+	// Add the block name
+	_ = writer.WriteField("block_name", dto.blockName)
+
+	// Add the language UUID
+	_ = writer.WriteField("language_uuid", dto.languageUUID)
+
+	// Add the test file
+	part, err := writer.CreateFormFile("test_archive", dto.testFile.Name())
+	if err != nil {
+		panic(err)
+	}
+	_, err = io.Copy(part, dto.testFile)
+	if err != nil {
+		panic(err)
+	}
+
+	// Close the multipart form
+	err = writer.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the request
+	endpoint := fmt.Sprintf("/api/v1/blocks/test_blocks/%s", dto.blockUUID)
+	r, err := http.NewRequest("PUT", endpoint, &body)
+	if err != nil {
+		panic(err)
+	}
+	r.Header.Add("Content-Type", writer.FormDataContentType())
+	r.AddCookie(dto.cookie)
+
+	// Send the request
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+
+	// Parse the response
 	jsonResponse := ParseJsonResponse(w.Body)
 	return jsonResponse, w.Code
 }

--- a/__tests__/integration/blocks_utils_test.go
+++ b/__tests__/integration/blocks_utils_test.go
@@ -7,7 +7,7 @@ import (
 
 func UpdateMarkdownBlockContent(cookie *http.Cookie, blockUUID string, payload map[string]interface{}) (response map[string]interface{}, statusCode int) {
 	endpoint := fmt.Sprintf("/api/v1/blocks/markdown_blocks/%s/content", blockUUID)
-	w, r := PrepareRequest("PUT", endpoint, payload)
+	w, r := PrepareRequest("PATCH", endpoint, payload)
 	r.AddCookie(cookie)
 	router.ServeHTTP(w, r)
 

--- a/__tests__/integration/laboratorires_test.go
+++ b/__tests__/integration/laboratorires_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -306,25 +305,18 @@ func TestCreateTestBlock(t *testing.T) {
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
 	c.Equal(http.StatusCreated, status)
 
-	// Get the supported languages
-	languagesResponse, status := GetSupportedLanguages(cookie)
-	c.Equal(http.StatusOK, status)
-
-	languages := languagesResponse["languages"].([]interface{})
-	c.Greater(len(languages), 0)
-
-	firstLanguage := languages[0].(map[string]interface{})
-	firstLanguageUUID := firstLanguage["uuid"].(string)
+	// Get a supported language from the supported languages list
+	language := GetFirstSupportedLanguage(cookie)
+	languageUUID := language["uuid"].(string)
 
 	// Open `.zip` file from the data folder
-	TEST_FILE_PATH := "../data/java_tests_sample.zip"
-	zipFile, err := os.Open(TEST_FILE_PATH)
+	zipFile, err := GetSampleTestsArchive()
 	c.Nil(err)
 
 	// Send the request
 	response, _ := CreateTestBlock(&CreateTestBlockUtilsDTO{
 		laboratoryUUID: laboratoryUUID,
-		languageUUID:   firstLanguageUUID,
+		languageUUID:   languageUUID,
 		blockName:      "Create test block test - block",
 		cookie:         cookie,
 		testFile:       zipFile,

--- a/__tests__/integration/languages_test.go
+++ b/__tests__/integration/languages_test.go
@@ -37,6 +37,18 @@ func TestListSupportedLanguages(t *testing.T) {
 	c.Contains(languagesNames, "Java")
 }
 
+func GetFirstSupportedLanguage(cookie *http.Cookie) (language map[string]interface{}) {
+	w, r := PrepareRequest("GET", "/api/v1/languages", nil)
+	r.AddCookie(cookie)
+	router.ServeHTTP(w, r)
+
+	jsonResponse := ParseJsonResponse(w.Body)
+
+	languages := jsonResponse["languages"].([]interface{})
+	language = languages[0].(map[string]interface{})
+	return language
+}
+
 func TestGetLanguageTemplate(t *testing.T) {
 	c := require.New(t)
 
@@ -48,16 +60,8 @@ func TestGetLanguageTemplate(t *testing.T) {
 	router.ServeHTTP(w, r)
 	cookie := w.Result().Cookies()[0]
 
-	// Get the supported languages
-	response, statusCode := GetSupportedLanguages(cookie)
-	c.Equal(http.StatusOK, statusCode)
-
-	// Check the response
-	languages := response["languages"].([]interface{})
-	c.Greater(len(languages), 0)
-
-	// Get the first language
-	language := languages[0].(map[string]interface{})
+	// Get a supported language from the supported languages list
+	language := GetFirstSupportedLanguage(cookie)
 
 	// Get the language template
 	template, statusCode := GetLanguageTemplate(cookie, language["uuid"].(string))

--- a/__tests__/integration/main_test.go
+++ b/__tests__/integration/main_test.go
@@ -118,6 +118,17 @@ func registerBaseTeachers() {
 }
 
 // --- Helpers ---
+func GetSampleTestsArchive() (*os.File, error) {
+	TEST_FILE_PATH := "../data/java_tests_sample.zip"
+
+	zipFile, err := os.Open(TEST_FILE_PATH)
+	if err != nil {
+		return nil, err
+	}
+
+	return zipFile, nil
+}
+
 func PrepareRequest(method, endpoint string, payload interface{}) (*httptest.ResponseRecorder, *http.Request) {
 	var req *http.Request
 

--- a/docs/bruno/blocks/update-markdown-block-content.bru
+++ b/docs/bruno/blocks/update-markdown-block-content.bru
@@ -4,7 +4,7 @@ meta {
   seq: 1
 }
 
-put {
+patch {
   url: {{BASE_URL}}/blocks/markdown_blocks/eb4ef0ee-3865-44c3-8d52-2620fb2653e5/content
   body: json
   auth: none

--- a/docs/insomnia/collection.json
+++ b/docs/insomnia/collection.json
@@ -1,9 +1,81 @@
 {
   "_type": "export",
   "__export_format": 4,
-  "__export_date": "2023-12-29T19:18:12.594Z",
+  "__export_date": "2023-12-30T01:37:22.228Z",
   "__export_source": "insomnia.desktop.app:v8.5.1",
   "resources": [
+    {
+      "_id": "req_415eff49d69146239cb94e4840c73722",
+      "parentId": "fld_0f115af031f64a478dc8707d5aba1048",
+      "modified": 1703900064178,
+      "created": 1703898807668,
+      "url": "{{ _.BASE_URL }}/blocks/test_blocks/dac2c142-d38b-4fbd-aff8-47e0e72691de",
+      "name": "update-test-block",
+      "description": "",
+      "method": "PUT",
+      "body": {
+        "mimeType": "multipart/form-data",
+        "params": [
+          {
+            "id": "pair_5173b39b1c1e406f8bb56dd4079ba5af",
+            "name": "block_name",
+            "value": "First calculator operations test",
+            "description": ""
+          },
+          {
+            "id": "pair_ede3d4a98a15489abc3aadb0aa42211d",
+            "name": "language_uuid",
+            "value": "19c11b28-3d06-4c54-8946-6af8a28e8b07",
+            "description": ""
+          },
+          {
+            "id": "pair_a3ab32838c904b648f6076662ced16ab",
+            "name": "test_archive",
+            "value": "",
+            "description": "",
+            "type": "file",
+            "fileName": "/home/pacq/IdeaProjects/java.zip"
+          }
+        ]
+      },
+      "parameters": [],
+      "headers": [
+        { "name": "Content-Type", "value": "multipart/form-data" },
+        { "name": "User-Agent", "value": "insomnia/8.5.1" }
+      ],
+      "authentication": {},
+      "metaSortKey": -1703898807668,
+      "isPrivate": false,
+      "settingStoreCookies": true,
+      "settingSendCookies": true,
+      "settingDisableRenderRequestBody": false,
+      "settingEncodeUrl": true,
+      "settingRebuildPath": true,
+      "settingFollowRedirects": "global",
+      "_type": "request"
+    },
+    {
+      "_id": "fld_0f115af031f64a478dc8707d5aba1048",
+      "parentId": "wrk_015f06b0727b4d81af80c31f9fc4f68f",
+      "modified": 1703867530994,
+      "created": 1703867530994,
+      "name": "laboratories",
+      "description": "",
+      "environment": {},
+      "environmentPropertyOrder": null,
+      "metaSortKey": -1703867530994,
+      "_type": "request_group"
+    },
+    {
+      "_id": "wrk_015f06b0727b4d81af80c31f9fc4f68f",
+      "parentId": null,
+      "modified": 1703867428111,
+      "created": 1703867428111,
+      "name": "UPB Codelabs Multipart Form Request",
+      "description": "",
+      "scope": "collection",
+      "_type": "workspace"
+    },
     {
       "_id": "req_1f5b243091ed48d19b56b9e9f1b8b60a",
       "parentId": "fld_0f115af031f64a478dc8707d5aba1048",
@@ -55,31 +127,9 @@
       "_type": "request"
     },
     {
-      "_id": "fld_0f115af031f64a478dc8707d5aba1048",
-      "parentId": "wrk_015f06b0727b4d81af80c31f9fc4f68f",
-      "modified": 1703867530994,
-      "created": 1703867530994,
-      "name": "laboratories",
-      "description": "",
-      "environment": {},
-      "environmentPropertyOrder": null,
-      "metaSortKey": -1703867530994,
-      "_type": "request_group"
-    },
-    {
-      "_id": "wrk_015f06b0727b4d81af80c31f9fc4f68f",
-      "parentId": null,
-      "modified": 1703867428111,
-      "created": 1703867428111,
-      "name": "UPB Codelabs Multipart Form Request",
-      "description": "",
-      "scope": "collection",
-      "_type": "workspace"
-    },
-    {
       "_id": "req_81c24080612643dea636b43cba6a5c72",
       "parentId": "fld_e99fc9329e1e4e9ea4aad5ac37ff965c",
-      "modified": 1703867500413,
+      "modified": 1703899153011,
       "created": 1703867446159,
       "url": "{{ _.BASE_URL }}/session/login",
       "name": "login-as-teacher",
@@ -133,21 +183,21 @@
     {
       "_id": "jar_5128b6531490f5b58316ee3db66aec4f90c368ff",
       "parentId": "wrk_015f06b0727b4d81af80c31f9fc4f68f",
-      "modified": 1703867520274,
+      "modified": 1703899153428,
       "created": 1703867428114,
       "name": "Default Jar",
       "cookies": [
         {
           "key": "session",
-          "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1dWlkIjoiNWM2NjY5ZDgtODFiYi00NGEyLTk4YTMtMDRhNTBmY2I1NWU1Iiwicm9sZSI6InRlYWNoZXIiLCJpc3MiOiJjb2RlbGFicyIsImV4cCI6MTcwMzg4OTEyMCwibmJmIjoxNzAzODY3NTIwLCJpYXQiOjE3MDM4Njc1MjB9.XCEIBKwjjNLja0B1eYNlZIc51I5f5nHPic3UWLUC-lM",
+          "value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1dWlkIjoiNWM2NjY5ZDgtODFiYi00NGEyLTk4YTMtMDRhNTBmY2I1NWU1Iiwicm9sZSI6InRlYWNoZXIiLCJpc3MiOiJjb2RlbGFicyIsImV4cCI6MTcwMzkyMDc1MywibmJmIjoxNzAzODk5MTUzLCJpYXQiOjE3MDM4OTkxNTN9.S9LaOnSyqZXngnBoFzIQdd5fjvSrA4uouPIYpjWs5RA",
           "maxAge": 21600,
           "domain": "127.0.0.1",
           "path": "/",
           "httpOnly": true,
           "hostOnly": true,
           "creation": "2023-12-29T16:32:00.273Z",
-          "lastAccessed": "2023-12-29T16:32:00.273Z",
-          "id": "f3827bc3-8097-4fa7-8dfa-d3c3f7e032f9"
+          "lastAccessed": "2023-12-30T01:19:13.427Z",
+          "id": "a921c5dd-cc15-4419-88f1-0266c5f22db4"
         }
       ],
       "_type": "cookie_jar"

--- a/docs/openapi/spec.openapi.yaml
+++ b/docs/openapi/spec.openapi.yaml
@@ -1140,7 +1140,7 @@ paths:
                 $ref: "#/components/schemas/default_error_response"
 
   # Blocks
-  /markdown_blocks/{block_uuid}:
+  /blocks/markdown_blocks/{block_uuid}:
     delete:
       tags:
         - Blocks
@@ -1170,7 +1170,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/default_error_response"
 
-  /markdown_blocks/{block_uuid}/content:
+  /blocks/markdown_blocks/{block_uuid}/content:
     patch:
       tags:
         - Blocks
@@ -1209,7 +1209,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/default_error_response"
 
-  /test_blocks/{block_uuid}:
+  /blocks/test_blocks/{block_uuid}:
     put:
       tags:
         - Blocks

--- a/src/blocks/application/use_cases.go
+++ b/src/blocks/application/use_cases.go
@@ -4,10 +4,12 @@ import (
 	"github.com/UPB-Code-Labs/main-api/src/blocks/domain/definitions"
 	"github.com/UPB-Code-Labs/main-api/src/blocks/domain/dtos"
 	"github.com/UPB-Code-Labs/main-api/src/blocks/domain/errors"
+	languagesDefinitions "github.com/UPB-Code-Labs/main-api/src/languages/domain/definitions"
 )
 
 type BlocksUseCases struct {
-	BlocksRepository definitions.BlockRepository
+	BlocksRepository    definitions.BlockRepository
+	LanguagesRepository languagesDefinitions.LanguagesRepository
 }
 
 func (useCases *BlocksUseCases) UpdateMarkdownBlockContent(dto dtos.UpdateMarkdownBlockContentDTO) (err error) {
@@ -23,4 +25,40 @@ func (useCases *BlocksUseCases) UpdateMarkdownBlockContent(dto dtos.UpdateMarkdo
 
 	// Update the block
 	return useCases.BlocksRepository.UpdateMarkdownBlockContent(dto.BlockUUID, dto.Content)
+}
+
+func (useCases *BlocksUseCases) UpdateTestBlock(dto dtos.UpdateTestBlockDTO) (err error) {
+	// Validate the teacher is the owner of the block
+	ownsBlock, err := useCases.BlocksRepository.DoesTeacherOwnsTestBlock(dto.TeacherUUID, dto.BlockUUID)
+	if err != nil {
+		return err
+	}
+
+	if !ownsBlock {
+		return errors.TeacherDoesNotOwnBlock{}
+	}
+
+	// Validate the programming language exists
+	_, err = useCases.LanguagesRepository.GetByUUID(dto.LanguageUUID)
+	if err != nil {
+		return err
+	}
+
+	// Overwrite the block's tests archive if the teacher uploaded a new one
+	if dto.NewTestArchive != nil {
+		// Get the UUID of the block's tests archive
+		uuid, err := useCases.BlocksRepository.GetTestArchiveUUIDFromTestBlockUUID(dto.BlockUUID)
+		if err != nil {
+			return err
+		}
+
+		// Send the request to the microservice
+		err = useCases.BlocksRepository.OverwriteTestsArchive(uuid, dto.NewTestArchive)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Update the block
+	return useCases.BlocksRepository.UpdateTestBlock(&dto)
 }

--- a/src/blocks/domain/definitions/blocks_repository.go
+++ b/src/blocks/domain/definitions/blocks_repository.go
@@ -1,10 +1,28 @@
 package definitions
 
-import "mime/multipart"
+import (
+	"mime/multipart"
+
+	"github.com/UPB-Code-Labs/main-api/src/blocks/domain/dtos"
+)
 
 type BlockRepository interface {
+	// Update the markdown text of a markdown block
 	UpdateMarkdownBlockContent(blockUUID string, content string) (err error)
-	DoesTeacherOwnsMarkdownBlock(teacherUUID string, blockUUID string) (bool, error)
 
+	// Functions to check blocks ownership
+	DoesTeacherOwnsMarkdownBlock(teacherUUID string, blockUUID string) (bool, error)
+	DoesTeacherOwnsTestBlock(teacherUUID string, blockUUID string) (bool, error)
+
+	// Create a new test block
 	SaveTestsArchive(file *multipart.File) (uuid string, err error)
+
+	// Get the UUID of the `zip` archive saved in the static files microservice
+	GetTestArchiveUUIDFromTestBlockUUID(blockUUID string) (uuid string, err error)
+
+	// Overwrite the `zip` archive saved in the static files microservice
+	OverwriteTestsArchive(uuid string, file *multipart.File) (err error)
+
+	// Update the test block information in the database
+	UpdateTestBlock(*dtos.UpdateTestBlockDTO) (err error)
 }

--- a/src/blocks/domain/dtos/blocks_dtos.go
+++ b/src/blocks/domain/dtos/blocks_dtos.go
@@ -1,7 +1,17 @@
 package dtos
 
+import "mime/multipart"
+
 type UpdateMarkdownBlockContentDTO struct {
 	TeacherUUID string
 	BlockUUID   string
 	Content     string
+}
+
+type UpdateTestBlockDTO struct {
+	TeacherUUID    string
+	BlockUUID      string
+	LanguageUUID   string
+	Name           string
+	NewTestArchive *multipart.File
 }

--- a/src/blocks/domain/errors/blocks_errors.go
+++ b/src/blocks/domain/errors/blocks_errors.go
@@ -11,3 +11,13 @@ func (err TeacherDoesNotOwnBlock) Error() string {
 func (err TeacherDoesNotOwnBlock) StatusCode() int {
 	return http.StatusForbidden
 }
+
+type BlockNotFound struct{}
+
+func (err BlockNotFound) Error() string {
+	return "No block was found with the given UUID"
+}
+
+func (err BlockNotFound) StatusCode() int {
+	return http.StatusNotFound
+}

--- a/src/blocks/infrastructure/http/routes.go
+++ b/src/blocks/infrastructure/http/routes.go
@@ -18,10 +18,19 @@ func StartBlocksRoutes(g *gin.RouterGroup) {
 		UseCases: &useCases,
 	}
 
-	blocksGroup.PUT(
+	blocksGroup.PATCH(
 		"/markdown_blocks/:block_uuid/content",
 		shared_infrastructure.WithAuthenticationMiddleware(),
 		shared_infrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
 		controller.HandleUpdateMarkdownBlockContent,
 	)
+
+	/*
+		blocksGroup.PUT(
+			"/test_blocks/:block_uuid",
+			shared_infrastructure.WithAuthenticationMiddleware(),
+			shared_infrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
+			controller.HandleUpdateTestBlock,
+		)
+	*/
 }

--- a/src/blocks/infrastructure/http/routes.go
+++ b/src/blocks/infrastructure/http/routes.go
@@ -3,7 +3,8 @@ package http
 import (
 	"github.com/UPB-Code-Labs/main-api/src/blocks/application"
 	"github.com/UPB-Code-Labs/main-api/src/blocks/infrastructure/implementations"
-	shared_infrastructure "github.com/UPB-Code-Labs/main-api/src/shared/infrastructure"
+	languagesImplementations "github.com/UPB-Code-Labs/main-api/src/languages/infrastructure/implementations"
+	sharedInfrastructure "github.com/UPB-Code-Labs/main-api/src/shared/infrastructure"
 	"github.com/gin-gonic/gin"
 )
 
@@ -11,7 +12,8 @@ func StartBlocksRoutes(g *gin.RouterGroup) {
 	blocksGroup := g.Group("/blocks")
 
 	useCases := application.BlocksUseCases{
-		BlocksRepository: implementations.GetBlocksPostgresRepositoryInstance(),
+		BlocksRepository:    implementations.GetBlocksPostgresRepositoryInstance(),
+		LanguagesRepository: languagesImplementations.GetLanguagesRepositoryInstance(),
 	}
 
 	controller := BlocksController{
@@ -20,17 +22,15 @@ func StartBlocksRoutes(g *gin.RouterGroup) {
 
 	blocksGroup.PATCH(
 		"/markdown_blocks/:block_uuid/content",
-		shared_infrastructure.WithAuthenticationMiddleware(),
-		shared_infrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
+		sharedInfrastructure.WithAuthenticationMiddleware(),
+		sharedInfrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
 		controller.HandleUpdateMarkdownBlockContent,
 	)
 
-	/*
-		blocksGroup.PUT(
-			"/test_blocks/:block_uuid",
-			shared_infrastructure.WithAuthenticationMiddleware(),
-			shared_infrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
-			controller.HandleUpdateTestBlock,
-		)
-	*/
+	blocksGroup.PUT(
+		"/test_blocks/:block_uuid",
+		sharedInfrastructure.WithAuthenticationMiddleware(),
+		sharedInfrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
+		controller.HandleUpdateTestBlock,
+	)
 }

--- a/src/blocks/infrastructure/implementations/blocks_repository.go
+++ b/src/blocks/infrastructure/implementations/blocks_repository.go
@@ -12,6 +12,8 @@ import (
 	"net/textproto"
 	"time"
 
+	"github.com/UPB-Code-Labs/main-api/src/blocks/domain/dtos"
+	"github.com/UPB-Code-Labs/main-api/src/blocks/domain/errors"
 	sharedDomainErrors "github.com/UPB-Code-Labs/main-api/src/shared/domain/errors"
 	sharedInfrastructure "github.com/UPB-Code-Labs/main-api/src/shared/infrastructure"
 )
@@ -88,16 +90,198 @@ func (repository *BlocksPostgresRepository) DoesTeacherOwnsMarkdownBlock(teacher
 	return laboratoryTeacherUUID == teacherUUID, nil
 }
 
+func (repository *BlocksPostgresRepository) DoesTeacherOwnsTestBlock(teacherUUID string, blockUUID string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// Get the UUID of the laboratory the block belongs to
+	query := `
+		SELECT laboratory_id
+		FROM test_blocks
+		WHERE id = $1
+	`
+
+	row := repository.Connection.QueryRowContext(ctx, query, blockUUID)
+	var laboratoryUUID string
+	if err := row.Scan(&laboratoryUUID); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+	}
+
+	// Check if the teacher owns the laboratory
+	query = `
+		SELECT teacher_id
+		FROM courses
+		WHERE id = (
+			SELECT course_id
+			FROM laboratories
+			WHERE id = $1
+		)
+	`
+
+	row = repository.Connection.QueryRowContext(ctx, query, laboratoryUUID)
+	var laboratoryTeacherUUID string
+	if err := row.Scan(&laboratoryTeacherUUID); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+	}
+
+	return laboratoryTeacherUUID == teacherUUID, nil
+}
+
+func (repository *BlocksPostgresRepository) GetTestArchiveUUIDFromTestBlockUUID(blockUUID string) (uuid string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	query := `
+		SELECT file_id
+		FROM archives
+		WHERE id = (
+			SELECT test_archive_id
+			FROM test_blocks
+			WHERE id = $1
+		)
+	`
+
+	row := repository.Connection.QueryRowContext(ctx, query, blockUUID)
+
+	// Parse the row
+	err = row.Scan(&uuid)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", &errors.BlockNotFound{}
+		}
+
+		return "", err
+	}
+
+	return uuid, nil
+}
+
 func (repository *BlocksPostgresRepository) SaveTestsArchive(file *multipart.File) (uuid string, err error) {
-	// Arbitrary constants since they are not used anywhere else and
-	// we only support zip files for now.
+	// Create multipart writer
+	staticFilesEndpoint := fmt.Sprintf("%s/archives/save", sharedInfrastructure.GetEnvironment().StaticFilesMicroserviceAddress)
+	baseMultipartBuffer, err := repository.getMultipartFormBuffer(
+		staticFilesEndpoint,
+		file,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// Add the file type field to the request
+	err = baseMultipartBuffer.bodyBufferWriter.WriteField("archive_type", "test")
+	if err != nil {
+		return "", err
+	}
+
+	// Close the writer
+	err = baseMultipartBuffer.bodyBufferWriter.Close()
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare the request
+	req, err := http.NewRequest("POST", staticFilesEndpoint, baseMultipartBuffer.bodyBuffer)
+
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Content-Type", baseMultipartBuffer.bodyBufferWriter.FormDataContentType())
+
+	// Send the request
+	client := &http.Client{}
+	res, err := client.Do(req)
+
+	// Forward error message if any
+	microserviceError := sharedInfrastructure.ParseMicroserviceError(res, err)
+	if microserviceError != nil {
+		return "", microserviceError
+	}
+
+	// Return the UUID of the saved file
+	var response map[string]interface{}
+	err = json.NewDecoder(res.Body).Decode(&response)
+	if err != nil {
+		return "", err
+	}
+
+	if response["uuid"] == nil {
+		return "", &sharedDomainErrors.GenericDomainError{
+			Code:    http.StatusInternalServerError,
+			Message: "The static files microservice did not return the UUID of the saved file",
+		}
+	}
+
+	return response["uuid"].(string), nil
+}
+
+func (repository *BlocksPostgresRepository) OverwriteTestsArchive(uuid string, file *multipart.File) (err error) {
+	// Create multipart writer
+	staticFilesEndpoint := fmt.Sprintf("%s/archives/overwrite", sharedInfrastructure.GetEnvironment().StaticFilesMicroserviceAddress)
+	baseMultipartBuffer, err := repository.getMultipartFormBuffer(
+		staticFilesEndpoint,
+		file,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Add the file type field to the request
+	err = baseMultipartBuffer.bodyBufferWriter.WriteField("archive_type", "test")
+	if err != nil {
+		return err
+	}
+
+	// Add the archive uuid field to the request
+	err = baseMultipartBuffer.bodyBufferWriter.WriteField("archive_uuid", uuid)
+	if err != nil {
+		return err
+	}
+
+	// Close the writer
+	err = baseMultipartBuffer.bodyBufferWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	// Prepare the request
+	req, err := http.NewRequest("PUT", staticFilesEndpoint, baseMultipartBuffer.bodyBuffer)
+
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", baseMultipartBuffer.bodyBufferWriter.FormDataContentType())
+
+	// Send the request
+	client := &http.Client{}
+	res, err := client.Do(req)
+
+	// Forward error message if any
+	microserviceError := sharedInfrastructure.ParseMicroserviceError(res, err)
+	if microserviceError != nil {
+		return microserviceError
+	}
+
+	return nil
+}
+
+type baseMultipartFormBuffer struct {
+	bodyBuffer       *bytes.Buffer
+	bodyBufferWriter *multipart.Writer
+}
+
+func (repository *BlocksPostgresRepository) getMultipartFormBuffer(endpoint string, file *multipart.File) (br *baseMultipartFormBuffer, err error) {
 	FILE_NAME := "archive.zip"
 	FILE_CONTENT_TYPE := "application/zip"
 
 	// Create multipart writer
-	staticFilesEndpoint := fmt.Sprintf("%s/archives/save", sharedInfrastructure.GetEnvironment().StaticFilesMicroserviceAddress)
-	var requestBuffer bytes.Buffer
-	multipartWriter := multipart.NewWriter(&requestBuffer)
+	var bodyBuffer bytes.Buffer
+	multipartWriter := multipart.NewWriter(&bodyBuffer)
 
 	// Add the file field to the request
 	header := textproto.MIMEHeader{}
@@ -113,61 +297,40 @@ func (repository *BlocksPostgresRepository) SaveTestsArchive(file *multipart.Fil
 	// Reset the file pointer to the beginning
 	_, err = (*file).Seek(0, io.SeekStart)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
+	// Add the file to the request
 	fileWriter, err := multipartWriter.CreatePart(header)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if _, err := io.Copy(fileWriter, *file); err != nil {
-		return "", err
+		return nil, err
 	}
 
-	// Add the file type field to the request
-	if err := multipartWriter.WriteField("archive_type", "test"); err != nil {
-		return "", err
-	}
+	return &baseMultipartFormBuffer{
+		bodyBuffer:       &bodyBuffer,
+		bodyBufferWriter: multipartWriter,
+	}, nil
+}
 
-	// Close the writer
-	err = multipartWriter.Close()
+func (repository *BlocksPostgresRepository) UpdateTestBlock(dto *dtos.UpdateTestBlockDTO) (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	// Update the block
+	query := `
+		UPDATE test_blocks
+		SET language_id = $1, name = $2
+		WHERE id = $3
+	`
+
+	_, err = repository.Connection.ExecContext(ctx, query, dto.LanguageUUID, dto.Name, dto.BlockUUID)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	// Prepare the request
-	req, err := http.NewRequest("POST", staticFilesEndpoint, &requestBuffer)
-
-	if err != nil {
-		return "", err
-	}
-
-	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
-
-	// Send the request
-	client := &http.Client{}
-	res, err := client.Do(req)
-
-	// Forward error message if any
-	microserviceError := sharedInfrastructure.ParseMicroserviceError(res, err)
-	if microserviceError != nil {
-		return "", microserviceError
-	}
-
-	// Parse the response
-	var response map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&response)
-	if err != nil {
-		return "", err
-	}
-
-	if response["uuid"] == nil {
-		return "", &sharedDomainErrors.StaticFilesMicroserviceError{
-			Code:    http.StatusInternalServerError,
-			Message: "The static files microservice did not return the UUID of the saved file",
-		}
-	}
-
-	return response["uuid"].(string), nil
+	return nil
 }

--- a/src/blocks/infrastructure/requests/blocks_requests.go
+++ b/src/blocks/infrastructure/requests/blocks_requests.go
@@ -3,3 +3,8 @@ package requests
 type UpdateMarkdownBlockContentRequest struct {
 	Content string `json:"content" validate:"required"`
 }
+
+type UpdateTestBlockRequest struct {
+	LanguageUUID string `validate:"required,uuid4"`
+	Name         string `validate:"required,min=4,max=255"`
+}

--- a/src/languages/application/usec_cases.go
+++ b/src/languages/application/usec_cases.go
@@ -15,7 +15,7 @@ func (useCases *LanguageUseCases) GetLanguages() ([]*entities.Language, error) {
 
 func (useCases *LanguageUseCases) GetLanguageTemplate(uuid string) ([]byte, error) {
 	// Get the information of the language from the database
-	langTemplateUUID, err := useCases.LanguageRepository.GetTemplateUUIDByLanguageUUID(uuid)
+	langTemplateUUID, err := useCases.LanguageRepository.GetTemplateArchiveUUIDByLanguageUUID(uuid)
 	if err != nil {
 		return nil, err
 	}

--- a/src/languages/domain/definitions/languages_repository.go
+++ b/src/languages/domain/definitions/languages_repository.go
@@ -6,6 +6,6 @@ type LanguagesRepository interface {
 	GetAll() (languages []*entities.Language, err error)
 	GetByUUID(uuid string) (language *entities.Language, err error)
 
-	GetTemplateUUIDByLanguageUUID(uuid string) (templateUUID string, err error)
+	GetTemplateArchiveUUIDByLanguageUUID(uuid string) (templateUUID string, err error)
 	GetTemplateBytes(uuid string) (template []byte, err error)
 }

--- a/src/languages/infrastructure/implementations/languages_repository.go
+++ b/src/languages/infrastructure/implementations/languages_repository.go
@@ -88,13 +88,12 @@ func (repository *LanguagesRepository) GetByUUID(uuid string) (language *entitie
 	return language, nil
 }
 
-func (repository *LanguagesRepository) GetTemplateUUIDByLanguageUUID(uuid string) (templateUUID string, err error) {
+func (repository *LanguagesRepository) GetTemplateArchiveUUIDByLanguageUUID(uuid string) (templateUUID string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
 	query := `
-		SELECT 
-		file_id
+		SELECT file_id
 		FROM archives
 		WHERE id = (
 			SELECT

--- a/src/shared/domain/errors/errors.go
+++ b/src/shared/domain/errors/errors.go
@@ -5,15 +5,15 @@ type DomainError interface {
 	StatusCode() int
 }
 
-type StaticFilesMicroserviceError struct {
+type GenericDomainError struct {
 	Code    int
 	Message string
 }
 
-func (err *StaticFilesMicroserviceError) Error() string {
+func (err *GenericDomainError) Error() string {
 	return err.Message
 }
 
-func (err *StaticFilesMicroserviceError) StatusCode() int {
+func (err *GenericDomainError) StatusCode() int {
 	return err.Code
 }

--- a/src/shared/infrastructure/utils.go
+++ b/src/shared/infrastructure/utils.go
@@ -3,17 +3,58 @@ package infrastructure
 import (
 	"encoding/json"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"time"
 
 	sharedDomainErrors "github.com/UPB-Code-Labs/main-api/src/shared/domain/errors"
+	"github.com/gabriel-vasile/mimetype"
 )
 
+// ParseISODate parses a date in ISO format received from a date-time input
 func ParseISODate(date string) (time.Time, error) {
 	layout := "2006-01-02T15:04"
 	return time.Parse(layout, date)
 }
 
+// ValidateMultipartFileHeader validates the multipart archive according to the
+// environment configuration and domain rules
+func ValidateMultipartFileHeader(multipartHeader *multipart.FileHeader) error {
+	if multipartHeader.Size > GetEnvironment().ArchiveMaxSizeKb*1024 {
+		return &sharedDomainErrors.GenericDomainError{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("The archive must be less than %d KB", GetEnvironment().ArchiveMaxSizeKb),
+		}
+	}
+
+	file, err := multipartHeader.Open()
+	if err != nil {
+		return &sharedDomainErrors.GenericDomainError{
+			Code:    http.StatusInternalServerError,
+			Message: "There was an error while reading the test archive",
+		}
+	}
+	defer file.Close()
+
+	mtype, err := mimetype.DetectReader(file)
+	if err != nil {
+		return &sharedDomainErrors.GenericDomainError{
+			Code:    http.StatusInternalServerError,
+			Message: "There was an error while reading the MIME type of the test archive",
+		}
+	}
+
+	if mtype.String() != "application/zip" {
+		return &sharedDomainErrors.GenericDomainError{
+			Code:    http.StatusBadRequest,
+			Message: "Please, make sure to send a ZIP archive",
+		}
+	}
+
+	return nil
+}
+
+// ParseMicroserviceError parses the error returned by the archives microservice
 func ParseMicroserviceError(resp *http.Response, err error) error {
 	statusStr := fmt.Sprintf("%d", resp.StatusCode)
 	isInTwoHundredsGroup := statusStr[0] == '2'
@@ -26,7 +67,7 @@ func ParseMicroserviceError(resp *http.Response, err error) error {
 		var responseJSON map[string]interface{}
 		err := json.NewDecoder(resp.Body).Decode(&responseJSON)
 		if err != nil {
-			return &sharedDomainErrors.StaticFilesMicroserviceError{
+			return &sharedDomainErrors.GenericDomainError{
 				Code:    http.StatusBadRequest,
 				Message: defaultErrorMessage,
 			}
@@ -39,7 +80,7 @@ func ParseMicroserviceError(resp *http.Response, err error) error {
 		}
 
 		// Return the error
-		return &sharedDomainErrors.StaticFilesMicroserviceError{
+		return &sharedDomainErrors.GenericDomainError{
 			Code:    resp.StatusCode,
 			Message: errorMessage,
 		}


### PR DESCRIPTION
## Includes 📋

- Change `/blocks/markdown_blocks/{block_uuid}/content` endpoint from `PUT` to `PATCH` according to the `openapi` spec.
- Various refactors
- New endpoint to update the text metadata (Such name) and test archive of test blocks. A request is sent to the `Static Files Microservice` to overwrite the `.zip` archive if the teachers sends a new one. 

## Related Issues 🔎

Closes #116 

<!-- 
## Notes 📝

Additional notes or implementation details. -->
