### PR TITLE
fix: Update test block without sending a new test archive

### DIFF
--- a/__tests__/integration/blocks_test.go
+++ b/__tests__/integration/blocks_test.go
@@ -186,6 +186,28 @@ func TestUpdateTestBlock(t *testing.T) {
 	block := blocks[0].(map[string]interface{})
 	c.Equal(newName, block["name"].(string))
 	c.Equal(firstLanguageUUID, block["language_uuid"].(string))
+
+	// Update the test block without sending a new test archive
+	newName = "Update test block test - block - updated - 2"
+	_, status = UpdateTestBlock(&UpdateTestBlockUtilsDTO{
+		blockUUID:    testBlockUUID,
+		languageUUID: firstLanguageUUID,
+		blockName:    newName,
+		cookie:       cookie,
+		testFile:     nil,
+	})
+	c.Equal(http.StatusNoContent, status)
+
+	// Check that the test block data was updated
+	laboratoryResponse, status = GetLaboratoryByUUID(cookie, laboratoryUUID)
+	c.Equal(http.StatusOK, status)
+
+	blocks = laboratoryResponse["test_blocks"].([]interface{})
+	c.Equal(1, len(blocks))
+
+	block = blocks[0].(map[string]interface{})
+	c.Equal(newName, block["name"].(string))
+	c.Equal(firstLanguageUUID, block["language_uuid"].(string))
 }
 
 func TestDeleteTestBlock(t *testing.T) {

--- a/__tests__/integration/blocks_utils_test.go
+++ b/__tests__/integration/blocks_utils_test.go
@@ -52,19 +52,21 @@ func UpdateTestBlock(dto *UpdateTestBlockUtilsDTO) (response map[string]interfac
 	_ = writer.WriteField("language_uuid", dto.languageUUID)
 
 	// Add the test file
-	part, err := writer.CreateFormFile("test_archive", dto.testFile.Name())
-	if err != nil {
-		panic(err)
-	}
-	_, err = io.Copy(part, dto.testFile)
-	if err != nil {
-		panic(err)
-	}
+	if dto.testFile != nil {
+		part, err := writer.CreateFormFile("test_archive", dto.testFile.Name())
+		if err != nil {
+			panic(err)
+		}
+		_, err = io.Copy(part, dto.testFile)
+		if err != nil {
+			panic(err)
+		}
 
-	// Close the multipart form
-	err = writer.Close()
-	if err != nil {
-		panic(err)
+		// Close the multipart form
+		err = writer.Close()
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	// Create the request

--- a/__tests__/integration/blocks_utils_test.go
+++ b/__tests__/integration/blocks_utils_test.go
@@ -61,12 +61,12 @@ func UpdateTestBlock(dto *UpdateTestBlockUtilsDTO) (response map[string]interfac
 		if err != nil {
 			panic(err)
 		}
+	}
 
-		// Close the multipart form
-		err = writer.Close()
-		if err != nil {
-			panic(err)
-		}
+	// Close the multipart form
+	err := writer.Close()
+	if err != nil {
+		panic(err)
 	}
 
 	// Create the request

--- a/src/blocks/infrastructure/http/controllers.go
+++ b/src/blocks/infrastructure/http/controllers.go
@@ -91,10 +91,12 @@ func (controller *BlocksController) HandleUpdateTestBlock(c *gin.Context) {
 	// Validate the test archive (if any)
 	multipartHeader, err := c.FormFile("test_archive")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"message": "Please, make sure to send the test archive",
-		})
-		return
+		if err != http.ErrMissingFile {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"message": "Please, make sure to send the test archive",
+			})
+			return
+		}
 	}
 
 	if multipartHeader != nil {


### PR DESCRIPTION
## Includes 📋

- Teachers are now able to update the information of tests blocks such as the name and language without needing to send a new test archive. 

## Related Issues 🔎

Fixes #134 

<!-- 
## Notes 📝

Additional notes or implementation details. -->
