### PR TITLE
feat: Get resumed information of a laboratory

### DIFF
--- a/__tests__/integration/laboratories_utils_test.go
+++ b/__tests__/integration/laboratories_utils_test.go
@@ -28,6 +28,16 @@ func GetLaboratoryByUUID(cookie *http.Cookie, uuid string) (response map[string]
 	return jsonResponse, w.Code
 }
 
+func GetLaboratoryInformationByUUID(cookie *http.Cookie, uuid string) (response map[string]interface{}, statusCode int) {
+	endpoint := fmt.Sprintf("/api/v1/laboratories/%s/information", uuid)
+	w, r := PrepareRequest("GET", endpoint, nil)
+	r.AddCookie(cookie)
+	router.ServeHTTP(w, r)
+
+	jsonResponse := ParseJsonResponse(w.Body)
+	return jsonResponse, w.Code
+}
+
 func UpdateLaboratory(cookie *http.Cookie, uuid string, payload map[string]interface{}) (response map[string]interface{}, statusCode int) {
 	w, r := PrepareRequest("PUT", "/api/v1/laboratories/"+uuid, payload)
 	r.AddCookie(cookie)

--- a/__tests__/integration/laboratorires_test.go
+++ b/__tests__/integration/laboratorires_test.go
@@ -81,10 +81,11 @@ func TestGetLaboratoryByUUID(t *testing.T) {
 	c.Equal(http.StatusCreated, status)
 
 	// Define tests cases
+	randomUUID := "4e2ba78e-a8f0-4312-b4a7-e8c6933029b8"
 	testCases := []GenericTestCase{
 		{
 			Payload: map[string]interface{}{
-				"laboratory_uuid": "4e2ba78e-a8f0-4312-b4a7-e8c6933029b8",
+				"laboratory_uuid": randomUUID,
 			},
 			ExpectedStatusCode: http.StatusNotFound,
 		},
@@ -104,10 +105,20 @@ func TestGetLaboratoryByUUID(t *testing.T) {
 
 	// Run tests
 	for _, tc := range testCases {
-		getLaboratoryResponse, status := GetLaboratoryByUUID(cookie, tc.Payload["laboratory_uuid"].(string))
+		getLaboratoryResponse, status := GetLaboratoryByUUID(
+			cookie,
+			tc.Payload["laboratory_uuid"].(string),
+		)
+		c.Equal(tc.ExpectedStatusCode, status)
+
+		getLaboratoryInformationResponse, status := GetLaboratoryInformationByUUID(
+			cookie,
+			tc.Payload["laboratory_uuid"].(string),
+		)
 		c.Equal(tc.ExpectedStatusCode, status)
 
 		if tc.ExpectedStatusCode == http.StatusOK {
+			// ## Validate laboratory request
 			// Validate string fields
 			c.Equal(laboratoryUUID, getLaboratoryResponse["uuid"])
 			c.Equal(laboratoryName, getLaboratoryResponse["name"])
@@ -118,6 +129,13 @@ func TestGetLaboratoryByUUID(t *testing.T) {
 			// Validate blocks fields
 			c.Equal(0, len(getLaboratoryResponse["markdown_blocks"].([]interface{})))
 			c.Equal(0, len(getLaboratoryResponse["test_blocks"].([]interface{})))
+
+			// ## Validate laboratory information request
+			c.Equal(laboratoryUUID, getLaboratoryInformationResponse["uuid"])
+			c.Equal(laboratoryName, getLaboratoryInformationResponse["name"])
+			c.Nil(getLaboratoryInformationResponse["rubric_uuid"])
+			c.Contains(getLaboratoryInformationResponse["opening_date"], laboratoryOpeningDate)
+			c.Contains(getLaboratoryInformationResponse["due_date"], laboratoryDueDate)
 		}
 	}
 }
@@ -327,7 +345,7 @@ func TestCreateTestBlock(t *testing.T) {
 	c.Contains(response, "uuid")
 }
 
-func TestGetStudentsProgres(t *testing.T) {
+func TestGetStudentsProgress(t *testing.T) {
 	c := require.New(t)
 
 	// ## Prepare

--- a/docs/bruno/laboratories/get-laboratory-information-by-uuid.bru
+++ b/docs/bruno/laboratories/get-laboratory-information-by-uuid.bru
@@ -1,0 +1,11 @@
+meta {
+  name: get-laboratory-information-by-uuid
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{BASE_URL}}/laboratories/a9be2f1e-e0e9-4b8d-9f72-6ed55ea5b1b8
+  body: none
+  auth: none
+}

--- a/src/laboratories/application/use_cases.go
+++ b/src/laboratories/application/use_cases.go
@@ -58,6 +58,29 @@ func (useCases *LaboratoriesUseCases) GetLaboratory(dto *dtos.GetLaboratoryDTO) 
 	return laboratory, nil
 }
 
+func (useCases *LaboratoriesUseCases) GetLaboratoryInformation(dto *dtos.GetLaboratoryDTO) (laboratoryInformation *dtos.LaboratoryDetailsDTO, err error) {
+	// Get the laboratory
+	laboratoryInformation, err = useCases.LaboratoriesRepository.GetLaboratoryInformationByUUID(dto.LaboratoryUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the user is enrolled in the course
+	isEnrolled, err := useCases.CoursesRepository.IsUserInCourse(
+		dto.UserUUID,
+		laboratoryInformation.CourseUUID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isEnrolled {
+		return nil, coursesErrors.UserNotInCourseError{}
+	}
+
+	return laboratoryInformation, nil
+}
+
 func (useCases *LaboratoriesUseCases) UpdateLaboratory(dto *dtos.UpdateLaboratoryDTO) error {
 	// Check that the teacher owns the laboratory / course
 	teacherOwnsLaboratory, err := useCases.doesTeacherOwnsLaboratory(dto.TeacherUUID, dto.LaboratoryUUID)

--- a/src/laboratories/domain/definitions/laboratories_repository.go
+++ b/src/laboratories/domain/definitions/laboratories_repository.go
@@ -7,6 +7,7 @@ import (
 
 type LaboratoriesRepository interface {
 	GetLaboratoryByUUID(uuid string) (laboratory *entities.Laboratory, err error)
+	GetLaboratoryInformationByUUID(uuid string) (laboratory *dtos.LaboratoryDetailsDTO, err error)
 	SaveLaboratory(dto *dtos.CreateLaboratoryDTO) (laboratory *entities.Laboratory, err error)
 	UpdateLaboratory(dto *dtos.UpdateLaboratoryDTO) error
 

--- a/src/laboratories/domain/dtos/laboratories_dtos.go
+++ b/src/laboratories/domain/dtos/laboratories_dtos.go
@@ -56,3 +56,12 @@ type LaboratoryStudentProgressDTO struct {
 	FailingSubmissions int    `json:"failing_submissions"`
 	SuccessSubmissions int    `json:"success_submissions"`
 }
+
+type LaboratoryDetailsDTO struct {
+	UUID        string  `json:"uuid"`
+	CourseUUID  string  `json:"-"`
+	RubricUUID  *string `json:"rubric_uuid"`
+	Name        string  `json:"name"`
+	OpeningDate string  `json:"opening_date"`
+	DueDate     string  `json:"due_date"`
+}

--- a/src/laboratories/infrastructure/http/controllers.go
+++ b/src/laboratories/infrastructure/http/controllers.go
@@ -94,6 +94,34 @@ func (controller *LaboratoriesController) HandleGetLaboratory(c *gin.Context) {
 	c.JSON(http.StatusOK, laboratory)
 }
 
+func (controller *LaboratoriesController) HandleGetLaboratoryInformation(c *gin.Context) {
+	teacherUUID := c.GetString("session_uuid")
+	laboratoryUUID := c.Param("laboratory_uuid")
+
+	// Validate the laboratory UUID
+	if err := infrastructure.GetValidator().Var(laboratoryUUID, "uuid4"); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Laboratory UUID is not valid",
+		})
+		return
+	}
+
+	// Get laboratory information
+	dto := dtos.GetLaboratoryDTO{
+		LaboratoryUUID: laboratoryUUID,
+		UserUUID:       teacherUUID,
+	}
+
+	information, err := controller.UseCases.GetLaboratoryInformation(&dto)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	// Return laboratory information
+	c.JSON(http.StatusOK, information)
+}
+
 func (controller *LaboratoriesController) HandleUpdateLaboratory(c *gin.Context) {
 	teacherUUID := c.GetString("session_uuid")
 	laboratoryUUID := c.Param("laboratory_uuid")

--- a/src/laboratories/infrastructure/http/routes.go
+++ b/src/laboratories/infrastructure/http/routes.go
@@ -42,6 +42,13 @@ func StartLaboratoriesRoutes(g *gin.RouterGroup) {
 		controller.HandleGetLaboratory,
 	)
 
+	laboratoriesGroup.GET(
+		"/:laboratory_uuid/information",
+		infrastructure.WithAuthenticationMiddleware(),
+		infrastructure.WithAuthorizationMiddleware([]string{"teacher", "student"}),
+		controller.HandleGetLaboratoryInformation,
+	)
+
 	laboratoriesGroup.PUT(
 		"/:laboratory_uuid",
 		infrastructure.WithAuthenticationMiddleware(),


### PR DESCRIPTION
## Includes 📋

- New endpoint to allow teachers to get resumed information (without blocks) of a laboratory. 

## Related Issues 🔎

Closes #154 

<!-- 
## Notes 📝

Additional notes or implementation details. -->
