### PR TITLE
fix: Return test archive UUID when creating new test blocks

### DIFF
--- a/__tests__/integration/laboratorires_test.go
+++ b/__tests__/integration/laboratorires_test.go
@@ -340,9 +340,9 @@ func TestCreateTestBlock(t *testing.T) {
 		testFile:       zipFile,
 	})
 
-	// Validate the response
-	// c.Equal(http.StatusCreated, status)
-	c.Contains(response, "uuid")
+	c.Equal(http.StatusCreated, status)
+	c.NotEmpty(response["uuid"])
+	c.NotEmpty(response["test_archive_uuid"])
 }
 
 func TestGetStudentsProgress(t *testing.T) {

--- a/docs/openapi/spec.openapi.yaml
+++ b/docs/openapi/spec.openapi.yaml
@@ -1078,6 +1078,9 @@ paths:
                   uuid:
                     type: string
                     example: "dd5a2edf-8439-4fdc-97e8-6f0d45d6540a"
+                  test_archive_uuid:
+                    type: string
+                    example: "67a56a2a-b7b8-4369-b726-7b387b49d64e"
         "400":
           description: Required fields were missed or doesn't fulfill the required format.
           content:

--- a/src/laboratories/application/use_cases.go
+++ b/src/laboratories/application/use_cases.go
@@ -131,37 +131,37 @@ func (useCases *LaboratoriesUseCases) doesTeacherOwnsLaboratory(teacherUUID, lab
 	return useCases.CoursesRepository.DoesTeacherOwnsCourse(teacherUUID, laboratory.CourseUUID)
 }
 
-func (useCases *LaboratoriesUseCases) CreateTestBlock(dto *dtos.CreateTestBlockDTO) (blockUUID string, err error) {
+func (useCases *LaboratoriesUseCases) CreateTestBlock(reqDTO *dtos.CreateTestBlockDTO) (resDTO *dtos.CreatedTestBlockDTO, err error) {
 	// Check that the teacher owns the laboratory
-	teacherOwnsLaboratory, err := useCases.doesTeacherOwnsLaboratory(dto.TeacherUUID, dto.LaboratoryUUID)
+	teacherOwnsLaboratory, err := useCases.doesTeacherOwnsLaboratory(reqDTO.TeacherUUID, reqDTO.LaboratoryUUID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if !teacherOwnsLaboratory {
-		return "", &coursesErrors.TeacherDoesNotOwnsCourseError{}
+		return nil, &coursesErrors.TeacherDoesNotOwnsCourseError{}
 	}
 
 	// Check that the language exists
-	_, err = useCases.LanguagesRepository.GetByUUID(dto.LanguageUUID)
+	_, err = useCases.LanguagesRepository.GetByUUID(reqDTO.LanguageUUID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Send the file to the static files microservice
 	savedArchiveUUID, err := useCases.StaticFilesRepository.SaveArchive(
 		&staticFilesDTOs.SaveStaticFileDTO{
-			File:     dto.MultipartFile,
+			File:     reqDTO.MultipartFile,
 			FileType: "test",
 		},
 	)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	dto.TestArchiveUUID = savedArchiveUUID
+	reqDTO.TestArchiveUUID = savedArchiveUUID
 
 	// Save the information in the database
-	return useCases.LaboratoriesRepository.CreateTestBlock(dto)
+	return useCases.LaboratoriesRepository.CreateTestBlock(reqDTO)
 }
 
 func (useCases *LaboratoriesUseCases) GetLaboratoryProgress(dto *dtos.GetLaboratoryProgressDTO) (progress *dtos.LaboratoryProgressDTO, err error) {

--- a/src/laboratories/domain/definitions/laboratories_repository.go
+++ b/src/laboratories/domain/definitions/laboratories_repository.go
@@ -12,7 +12,7 @@ type LaboratoriesRepository interface {
 	UpdateLaboratory(dto *dtos.UpdateLaboratoryDTO) error
 
 	CreateMarkdownBlock(laboratoryUUID string) (blockUUID string, err error)
-	CreateTestBlock(dto *dtos.CreateTestBlockDTO) (blockUUID string, err error)
+	CreateTestBlock(dto *dtos.CreateTestBlockDTO) (CreatedTestBlockDTO *dtos.CreatedTestBlockDTO, err error)
 
 	GetTotalTestBlocks(laboratoryUUID string) (total int, err error)
 	GetStudentsProgress(laboratoryUUID string) (progress []*dtos.LaboratoryStudentProgressDTO, err error)

--- a/src/laboratories/domain/dtos/laboratories_dtos.go
+++ b/src/laboratories/domain/dtos/laboratories_dtos.go
@@ -38,6 +38,11 @@ type CreateTestBlockDTO struct {
 	MultipartFile   *multipart.File
 }
 
+type CreatedTestBlockDTO struct {
+	BlockUUID       string `json:"uuid"`
+	TestArchiveUUID string `json:"test_archive_uuid"`
+}
+
 type GetLaboratoryProgressDTO struct {
 	LaboratoryUUID string
 	TeacherUUID    string

--- a/src/laboratories/infrastructure/http/controllers.go
+++ b/src/laboratories/infrastructure/http/controllers.go
@@ -292,13 +292,11 @@ func (controller *LaboratoriesController) HandleCreateTestBlock(c *gin.Context) 
 	}
 
 	// Create the block
-	blockUUID, err := controller.UseCases.CreateTestBlock(&dto)
+	createdBlockDTO, err := controller.UseCases.CreateTestBlock(&dto)
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, gin.H{
-		"uuid": blockUUID,
-	})
+	c.JSON(http.StatusCreated, createdBlockDTO)
 }

--- a/src/laboratories/infrastructure/implementations/laboratories_respository.go
+++ b/src/laboratories/infrastructure/implementations/laboratories_respository.go
@@ -256,14 +256,14 @@ func (repository *LaboratoriesPostgresRepository) CreateMarkdownBlock(laboratory
 	return blockUUID, nil
 }
 
-func (repository *LaboratoriesPostgresRepository) CreateTestBlock(dto *dtos.CreateTestBlockDTO) (blockUUID string, err error) {
+func (repository *LaboratoriesPostgresRepository) CreateTestBlock(dto *dtos.CreateTestBlockDTO) (createdTestBlockDTO *dtos.CreatedTestBlockDTO, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
 	// Start transaction
 	tx, err := repository.Connection.BeginTx(ctx, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer tx.Rollback()
 
@@ -280,7 +280,7 @@ func (repository *LaboratoriesPostgresRepository) CreateTestBlock(dto *dtos.Crea
 	row := tx.QueryRowContext(ctx, query, dto.LaboratoryUUID)
 	var dbBlockIndexUUID string
 	if err := row.Scan(&dbBlockIndexUUID); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Save the archive metadata
@@ -291,9 +291,10 @@ func (repository *LaboratoriesPostgresRepository) CreateTestBlock(dto *dtos.Crea
 	`
 
 	row = tx.QueryRowContext(ctx, query, dto.TestArchiveUUID)
-	var dbArchiveUUID string
-	if err := row.Scan(&dbArchiveUUID); err != nil {
-		return "", err
+	createdTestBlockDTO = &dtos.CreatedTestBlockDTO{}
+
+	if err := row.Scan(&createdTestBlockDTO.TestArchiveUUID); err != nil {
+		return nil, err
 	}
 
 	// Create test block
@@ -307,23 +308,23 @@ func (repository *LaboratoriesPostgresRepository) CreateTestBlock(dto *dtos.Crea
 		ctx,
 		query,
 		dto.LanguageUUID,
-		dbArchiveUUID,
+		createdTestBlockDTO.TestArchiveUUID,
 		dto.LaboratoryUUID,
 		dbBlockIndexUUID,
 		dto.Name,
 	)
 
-	if err := row.Scan(&blockUUID); err != nil {
-		return "", err
+	if err := row.Scan(&createdTestBlockDTO.BlockUUID); err != nil {
+		return nil, err
 	}
 
 	// Commit transaction
 	if err := tx.Commit(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Return the new block UUID
-	return blockUUID, nil
+	return createdTestBlockDTO, nil
 }
 
 func (repository *LaboratoriesPostgresRepository) GetTotalTestBlocks(laboratoryUUID string) (total int, err error) {


### PR DESCRIPTION
## Includes 📋

- Add the test archive UUID to the response of the endpoint to create new test blocks. 

## Related Issues 🔎

Closes #152 

<!--
## Notes 📝

 Additional notes or implementation details. -->
