### PR TITLE
feat: Get user profile

### DIFF
--- a/__tests__/integration/accounts_utils_test.go
+++ b/__tests__/integration/accounts_utils_test.go
@@ -81,3 +81,34 @@ func UpdatePasswordUtil(dto UpdatePasswordUtilDTO) int {
 	router.ServeHTTP(w, r)
 	return w.Code
 }
+
+type UpdateProfileUtilDTO struct {
+	FullName        string
+	Email           string
+	Password        string
+	InstitutionalId *string
+	Cookie          *http.Cookie
+}
+
+// UpdateProfileUtil sends a request to update the profile of an account and returns the status code
+// of the response
+func UpdateProfileUtil(dto UpdateProfileUtilDTO) int {
+	w, r := PrepareRequest("PUT", "/api/v1/accounts/profile", map[string]interface{}{
+		"full_name":        dto.FullName,
+		"email":            dto.Email,
+		"password":         dto.Password,
+		"institutional_id": dto.InstitutionalId,
+	})
+	r.AddCookie(dto.Cookie)
+	router.ServeHTTP(w, r)
+	return w.Code
+}
+
+// GetProfileUtil sends a request to get the profile of an account and returns the JSON response
+// as a map and the status code of the response
+func GetProfileUtil(cookie *http.Cookie) (response map[string]interface{}, statusCode int) {
+	w, r := PrepareRequest("GET", "/api/v1/accounts/profile", nil)
+	r.AddCookie(cookie)
+	router.ServeHTTP(w, r)
+	return ParseJsonResponse(w.Body), w.Code
+}

--- a/docs/bruno/users/get-user-profile.bru
+++ b/docs/bruno/users/get-user-profile.bru
@@ -1,0 +1,11 @@
+meta {
+  name: get-user-profile
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{BASE_URL}}/accounts/profile
+  body: none
+  auth: none
+}

--- a/docs/bruno/users/update-profile.bru
+++ b/docs/bruno/users/update-profile.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: {{BASE_URL}}/accounts
+  url: {{BASE_URL}}/accounts/profile
   body: json
   auth: none
 }

--- a/docs/openapi/spec.openapi.yaml
+++ b/docs/openapi/spec.openapi.yaml
@@ -244,7 +244,33 @@ paths:
               schema:
                 $ref: "#/components/schemas/default_error_response"
   
-  /accounts:
+  /accounts/profile:
+    get: 
+      tags:
+        - Accounts
+      security:
+        - cookieAuth: []
+      description: Get the user's profile. This endpoint is necessary since we do not want to include sensitive data as the user full name and email and keep them in the session when the `/whoami` endpoint is requested. 
+      responses:
+        "200":
+          description: The profile details were obtained. 
+          content: 
+            application/json: 
+              schema: 
+                $ref: "#/components/schemas/account_profile_response"
+        "403":
+          description: The session token isn't valid or the user doesn't have enough permissions.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/default_error_response"
+        "500":
+          description: There was an unexpected error in the server side.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/default_error_response"  
+      
     put:
       tags: 
         - Accounts
@@ -2242,6 +2268,19 @@ components:
         role: 
           type: string
           example: "student"
+    
+    account_profile_response: 
+      type: object
+      properties: 
+        full_name: 
+          type: string
+          example: "Pedro Chaparro"
+        email: 
+          type: string
+          example: "pedrochaparro@upb.edu.co"
+        institutional_id:
+          type: string
+          example: "000371272"
 
     public_user_fields:
       type: object

--- a/src/accounts/application/use_cases.go
+++ b/src/accounts/application/use_cases.go
@@ -180,3 +180,24 @@ func (useCases *AccountsUseCases) UpdateProfile(dto dtos.UpdateAccountDTO) error
 	err = useCases.AccountsRepository.UpdateProfile(dto)
 	return err
 }
+
+func (useCases *AccountsUseCases) GetProfile(userUUID string) (*dtos.UserProfileDTO, error) {
+	// Get user
+	user, err := useCases.AccountsRepository.GetUserByUUID(userUUID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, errors.UserNotFoundError{}
+		}
+
+		return nil, err
+	}
+
+	// Create DTO
+	dto := dtos.UserProfileDTO{
+		FullName:        user.FullName,
+		Email:           user.Email,
+		InstitutionalId: &user.InstitutionalId,
+	}
+
+	return &dto, nil
+}

--- a/src/accounts/domain/dtos/accounts_dtos.go
+++ b/src/accounts/domain/dtos/accounts_dtos.go
@@ -21,3 +21,9 @@ type UpdateAccountDTO struct {
 	InstitutionalId *string
 	Password        string
 }
+
+type UserProfileDTO struct {
+	FullName        string  `json:"full_name"`
+	Email           string  `json:"email"`
+	InstitutionalId *string `json:"institutional_id"`
+}

--- a/src/accounts/infrastructure/http/controllers.go
+++ b/src/accounts/infrastructure/http/controllers.go
@@ -271,3 +271,18 @@ func (controller *AccountsController) HandleUpdateProfile(c *gin.Context) {
 
 	c.Status(http.StatusNoContent)
 }
+
+// HandleGetProfile controller to get the profile of an account
+func (controller *AccountsController) HandleGetProfile(c *gin.Context) {
+	userUUID := c.GetString("session_uuid")
+
+	// Get profile
+	profileDTO, err := controller.UseCases.GetProfile(userUUID)
+
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, profileDTO)
+}

--- a/src/accounts/infrastructure/http/routes.go
+++ b/src/accounts/infrastructure/http/routes.go
@@ -48,8 +48,13 @@ func StartAccountsRoutes(g *gin.RouterGroup) {
 		sharedInfrastructure.WithAuthenticationMiddleware(),
 		controller.HandleUpdatePassword,
 	)
+	accountsGroup.GET(
+		"/profile",
+		sharedInfrastructure.WithAuthenticationMiddleware(),
+		controller.HandleGetProfile,
+	)
 	accountsGroup.PUT(
-		"",
+		"/profile",
 		sharedInfrastructure.WithAuthenticationMiddleware(),
 		controller.HandleUpdateProfile,
 	)


### PR DESCRIPTION
## Includes 📋

- Change PUT `/accounts` endpoint to PUT `/accounts/profile`. 
- Create new endpoint to allow users to get their profile. 
- Add missing tests for the PUT `/accounts/profile` endpoint and add new tests for the new endpoint. 

## Related Issues 🔎

Closes #167 
Closes #161 

<!-- 
## Notes 📝

Additional notes or implementation details. -->
