### PR TITLE
feat: Download tests archive

### DIFF
--- a/__tests__/integration/blocks_utils_test.go
+++ b/__tests__/integration/blocks_utils_test.go
@@ -116,3 +116,12 @@ func SwapBlocks(dto *SwapBlocksUtilsDTO) (response map[string]interface{}, statu
 	jsonResponse := ParseJsonResponse(w.Body)
 	return jsonResponse, w.Code
 }
+
+func GetTestsArchive(testBlockUUID string, cookie *http.Cookie) (bytes []byte, statusCode int) {
+	endpoint := fmt.Sprintf("/api/v1/blocks/test_blocks/%s/tests_archive", testBlockUUID)
+	w, r := PrepareRequest("GET", endpoint, nil)
+	r.AddCookie(cookie)
+
+	router.ServeHTTP(w, r)
+	return w.Body.Bytes(), w.Code
+}

--- a/docs/bruno/blocks/download-test-block-tests-archive.bru
+++ b/docs/bruno/blocks/download-test-block-tests-archive.bru
@@ -1,0 +1,11 @@
+meta {
+  name: download-test-block-tests-archive
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{BASE_URL}}/blocks/test_blocks/b19c92d2-2669-4744-a540-d5a39a7f5481/tests_archive
+  body: none
+  auth: none
+}

--- a/docs/openapi/spec.openapi.yaml
+++ b/docs/openapi/spec.openapi.yaml
@@ -1144,9 +1144,6 @@ paths:
                   uuid:
                     type: string
                     example: "dd5a2edf-8439-4fdc-97e8-6f0d45d6540a"
-                  test_archive_uuid:
-                    type: string
-                    example: "67a56a2a-b7b8-4369-b726-7b387b49d64e"
         "400":
           description: Required fields were missed or doesn't fulfill the required format.
           content:
@@ -1446,6 +1443,47 @@ paths:
                 $ref: "#/components/schemas/default_error_response"
         "404":
           description: A block with (at least) one of the given UUIDs were not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/default_error_response"
+        "500":
+          description: There was an unexpected error in the server side.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/default_error_response"
+  
+  /blocks/test_blocks/{block_uuid}/tests_archive: 
+    get: 
+      tags:
+        - Blocks
+      security:
+        - cookieAuth: []
+      parameters:
+        - in: path
+          name: block_uuid
+          schema:
+            type: string
+            example: "dd5a2edf-8439-4fdc-97e8-6f0d45d6540a"
+          required: true
+      description: Get `.zip` archive with the tests for the given test block. 
+      responses:
+        "200":
+          description: The `.zip` archive is retrieved / downloaded
+          content: 
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: No test bblock found with the given UUID. 
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/default_error_response"
+        "403":
+          description: The session token isn't valid or the user doesn't have enough permissions.
           content:
             application/json:
               schema:

--- a/src/blocks/application/use_cases.go
+++ b/src/blocks/application/use_cases.go
@@ -193,3 +193,27 @@ func (useCases *BlocksUseCases) SwapBlocks(dto dtos.SwapBlocksDTO) (err error) {
 	// Swap the blocks
 	return useCases.BlocksRepository.SwapBlocks(dto.FirstBlockUUID, dto.SecondBlockUUID)
 }
+
+// GetTestBlockTestsArchive returns the bytes of the `.zip` archive containing the tests of a test block
+func (useCases *BlocksUseCases) GetTestBlockTestsArchive(dto *dtos.GetBlockTestsArchiveDTO) (archive []byte, err error) {
+	// Validate the teacher is the owner of the block
+	ownsBlock, err := useCases.BlocksRepository.DoesTeacherOwnsTestBlock(dto.TeacherUUID, dto.BlockUUID)
+	if err != nil {
+		return nil, err
+	}
+	if !ownsBlock {
+		return nil, blocksErrors.TeacherDoesNotOwnBlock{}
+	}
+
+	// Get the UUID of the block's tests archive
+	uuid, err := useCases.BlocksRepository.GetTestArchiveUUIDFromTestBlockUUID(dto.BlockUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the archive from the microservice
+	return useCases.StaticFilesRepository.GetArchiveBytes(&staticFilesDTOs.StaticFileArchiveDTO{
+		FileUUID: uuid,
+		FileType: "test",
+	})
+}

--- a/src/blocks/domain/dtos/blocks_dtos.go
+++ b/src/blocks/domain/dtos/blocks_dtos.go
@@ -26,3 +26,8 @@ type SwapBlocksDTO struct {
 	FirstBlockUUID  string
 	SecondBlockUUID string
 }
+
+type GetBlockTestsArchiveDTO struct {
+	TeacherUUID string
+	BlockUUID   string
+}

--- a/src/blocks/infrastructure/http/controllers.go
+++ b/src/blocks/infrastructure/http/controllers.go
@@ -213,3 +213,31 @@ func (controller *BlocksController) HandleSwapBlocks(c *gin.Context) {
 
 	c.Status(http.StatusNoContent)
 }
+
+// HandleGetTestBlockTestsArchive controller to handle the request of downloading the `.zip` archive
+// containing the tests of a test block
+func (controller *BlocksController) HandleGetTestBlockTestsArchive(c *gin.Context) {
+	teacherUUID := c.GetString("session_uuid")
+	blockUUID := c.Param("block_uuid")
+
+	// Validate the block UUID
+	if err := sharedInfrastructure.GetValidator().Var(blockUUID, "uuid4"); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Block UUID is not valid",
+		})
+		return
+	}
+
+	// Get the test block tests archive
+	testsArchive, err := controller.UseCases.GetTestBlockTestsArchive(&dtos.GetBlockTestsArchiveDTO{
+		TeacherUUID: teacherUUID,
+		BlockUUID:   blockUUID,
+	})
+
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.Data(http.StatusOK, "application/zip", testsArchive)
+}

--- a/src/blocks/infrastructure/http/routes.go
+++ b/src/blocks/infrastructure/http/routes.go
@@ -56,4 +56,11 @@ func StartBlocksRoutes(g *gin.RouterGroup) {
 		sharedInfrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
 		controller.HandleSwapBlocks,
 	)
+
+	blocksGroup.GET(
+		"/test_blocks/:block_uuid/tests_archive",
+		sharedInfrastructure.WithAuthenticationMiddleware(),
+		sharedInfrastructure.WithAuthorizationMiddleware([]string{"teacher"}),
+		controller.HandleGetTestBlockTestsArchive,
+	)
 }

--- a/src/laboratories/application/use_cases.go
+++ b/src/laboratories/application/use_cases.go
@@ -123,21 +123,21 @@ func (useCases *LaboratoriesUseCases) CreateMarkdownBlock(dto *dtos.CreateMarkdo
 	return useCases.LaboratoriesRepository.CreateMarkdownBlock(dto.LaboratoryUUID)
 }
 
-func (useCases *LaboratoriesUseCases) CreateTestBlock(reqDTO *dtos.CreateTestBlockDTO) (resDTO *dtos.CreatedTestBlockDTO, err error) {
+func (useCases *LaboratoriesUseCases) CreateTestBlock(reqDTO *dtos.CreateTestBlockDTO) (blockUUID string, err error) {
 	// Check that the teacher owns the laboratory
 	teacherOwnsLaboratory, err := useCases.LaboratoriesRepository.DoesTeacherOwnLaboratory(reqDTO.TeacherUUID, reqDTO.LaboratoryUUID)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	if !teacherOwnsLaboratory {
-		return nil, laboratoriesErrors.TeacherDoesNotOwnLaboratoryError{}
+		return "", laboratoriesErrors.TeacherDoesNotOwnLaboratoryError{}
 	}
 
 	// Check that the language exists
 	_, err = useCases.LanguagesRepository.GetByUUID(reqDTO.LanguageUUID)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Send the file to the static files microservice
@@ -148,7 +148,7 @@ func (useCases *LaboratoriesUseCases) CreateTestBlock(reqDTO *dtos.CreateTestBlo
 		},
 	)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	reqDTO.TestArchiveUUID = savedArchiveUUID
 

--- a/src/laboratories/domain/definitions/laboratories_repository.go
+++ b/src/laboratories/domain/definitions/laboratories_repository.go
@@ -12,7 +12,7 @@ type LaboratoriesRepository interface {
 	UpdateLaboratory(dto *dtos.UpdateLaboratoryDTO) error
 
 	CreateMarkdownBlock(laboratoryUUID string) (blockUUID string, err error)
-	CreateTestBlock(dto *dtos.CreateTestBlockDTO) (CreatedTestBlockDTO *dtos.CreatedTestBlockDTO, err error)
+	CreateTestBlock(dto *dtos.CreateTestBlockDTO) (blockUUID string, err error)
 
 	GetTotalTestBlocks(laboratoryUUID string) (total int, err error)
 	GetStudentsProgress(laboratoryUUID string) (progress []*dtos.LaboratoryStudentProgressDTO, err error)

--- a/src/laboratories/domain/dtos/laboratories_dtos.go
+++ b/src/laboratories/domain/dtos/laboratories_dtos.go
@@ -38,11 +38,6 @@ type CreateTestBlockDTO struct {
 	MultipartFile   *multipart.File
 }
 
-type CreatedTestBlockDTO struct {
-	BlockUUID       string `json:"uuid"`
-	TestArchiveUUID string `json:"test_archive_uuid"`
-}
-
 type GetLaboratoryProgressDTO struct {
 	LaboratoryUUID string
 	TeacherUUID    string

--- a/src/laboratories/infrastructure/http/controllers.go
+++ b/src/laboratories/infrastructure/http/controllers.go
@@ -292,11 +292,13 @@ func (controller *LaboratoriesController) HandleCreateTestBlock(c *gin.Context) 
 	}
 
 	// Create the block
-	createdBlockDTO, err := controller.UseCases.CreateTestBlock(&dto)
+	createdBlockUUID, err := controller.UseCases.CreateTestBlock(&dto)
 	if err != nil {
 		c.Error(err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, createdBlockDTO)
+	c.JSON(http.StatusCreated, gin.H{
+		"uuid": createdBlockUUID,
+	})
 }


### PR DESCRIPTION
## Includes 📋

- **Remove `tests_blocks_archive_uuid` from the response when creating test blocks:** The UUID of the test block itself is used to download the test archive. 
- **Endpoint to download the `zip` archive containing the tests of their test blocks:** Now, teachers are able to download the `.zip` archive with their tests. 

## Related Issues 🔎

Closes #173 

<!-- 
## Notes 📝

Additional notes or implementation details. -->
