### PR TITLE
fix: Add timezonone to laboratories dates

### DIFF
--- a/__tests__/integration/blocks_test.go
+++ b/__tests__/integration/blocks_test.go
@@ -26,8 +26,8 @@ func TestUpdateMarkdownBlockContent(t *testing.T) {
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Update markdown block content test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T12:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	c.Equal(http.StatusCreated, status)
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
@@ -87,8 +87,8 @@ func TestDeleteMarkdownBlock(t *testing.T) {
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Delete markdown block test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T12:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	c.Equal(http.StatusCreated, status)
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
@@ -132,8 +132,8 @@ func TestUpdateTestBlock(t *testing.T) {
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Update test block test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T00:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	c.Equal(http.StatusCreated, status)
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
@@ -229,8 +229,8 @@ func TestDeleteTestBlock(t *testing.T) {
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Delete test block test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T00:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	c.Equal(http.StatusCreated, status)
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
@@ -296,8 +296,8 @@ func TestSwapBlocks(t *testing.T) {
 	laboratoryCreationResponse, _ := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Swap blocks test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T00:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
 

--- a/__tests__/integration/courses_test.go
+++ b/__tests__/integration/courses_test.go
@@ -582,13 +582,11 @@ func TestGetCourseLaboratories(t *testing.T) {
 
 	// Create two laboratories
 	openLaboratoryName := "Get course laboratories test - open laboratory"
-	openLaboratoryOpeningDate := "2023-11-01T08:00"
-	openLaboratoryDueDate := "2023-11-07T00:00"
 	openLaboratoryCreationResponse, code := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         openLaboratoryName,
 		"course_uuid":  courseUUID,
-		"opening_date": openLaboratoryOpeningDate,
-		"due_date":     openLaboratoryDueDate,
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	c.Equal(http.StatusCreated, code)
 	openLaboratoryUUID := openLaboratoryCreationResponse["uuid"].(string)
@@ -597,8 +595,8 @@ func TestGetCourseLaboratories(t *testing.T) {
 	_, code = CreateLaboratory(cookie, map[string]interface{}{
 		"name":         futureLaboratoryName,
 		"course_uuid":  courseUUID,
-		"opening_date": "3023-11-01T08:00",
-		"due_date":     "3023-11-07T00:00",
+		"opening_date": "3023-11-01T12:00:00-05:00",
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	c.Equal(http.StatusCreated, code)
 
@@ -674,8 +672,8 @@ func TestGetCourseLaboratories(t *testing.T) {
 			laboratory := laboratories[0].(map[string]interface{})
 			c.Equal(openLaboratoryUUID, laboratory["uuid"])
 			c.Equal(openLaboratoryName, laboratory["name"])
-			c.Contains(laboratory["opening_date"], openLaboratoryOpeningDate)
-			c.Contains(laboratory["due_date"], openLaboratoryDueDate)
+			c.Equal(defaultLaboratoryOpeningDateUTC, laboratory["opening_date"])
+			c.Equal(defaultLaboratoryDueDateUTC, laboratory["due_date"])
 		}
 	}
 }

--- a/__tests__/integration/grades_test.go
+++ b/__tests__/integration/grades_test.go
@@ -27,14 +27,12 @@ func TestGradeStudentSubmission(t *testing.T) {
 
 	// Create a laboratory
 	laboratoryName := "Set criteria to student grade test - laboratory"
-	laboratoryOpeningDate := "2023-12-01T08:00"
-	laboratoryDueDate := "2023-12-01T12:00"
 
 	laboratoryCreationResponse, _ := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         laboratoryName,
 		"course_uuid":  courseUUID,
-		"opening_date": laboratoryOpeningDate,
-		"due_date":     laboratoryDueDate,
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
 
@@ -65,8 +63,8 @@ func TestGradeStudentSubmission(t *testing.T) {
 	UpdateLaboratory(cookie, laboratoryUUID, map[string]interface{}{
 		"rubric_uuid":  rubricUUID,
 		"name":         laboratoryName,
-		"opening_date": laboratoryOpeningDate,
-		"due_date":     laboratoryDueDate,
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 
 	// Add the student to the course

--- a/__tests__/integration/laboratorires_test.go
+++ b/__tests__/integration/laboratorires_test.go
@@ -38,8 +38,8 @@ func TestCreateLaboratory(t *testing.T) {
 			Payload: map[string]interface{}{
 				"name":         "Create laboratory test - laboratory",
 				"course_uuid":  courseUUID,
-				"opening_date": "2023-12-01T08:00",
-				"due_date":     "3023-12-01T12:00",
+				"opening_date": defaultLaboratoryOpeningDate,
+				"due_date":     defaultLaboratoryDueDate,
 			},
 			ExpectedStatusCode: http.StatusCreated,
 		},
@@ -69,14 +69,12 @@ func TestGetLaboratoryByUUID(t *testing.T) {
 
 	// Create a laboratory
 	laboratoryName := "Get laboratory by uuid test - laboratory"
-	laboratoryOpeningDate := "2023-12-01T08:00"
-	laboratoryDueDate := "2023-12-01T12:00"
 
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         laboratoryName,
 		"course_uuid":  courseUUID,
-		"opening_date": laboratoryOpeningDate,
-		"due_date":     laboratoryDueDate,
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
 	c.Equal(http.StatusCreated, status)
@@ -124,8 +122,8 @@ func TestGetLaboratoryByUUID(t *testing.T) {
 			c.Equal(laboratoryUUID, getLaboratoryResponse["uuid"])
 			c.Equal(laboratoryName, getLaboratoryResponse["name"])
 			c.Nil(getLaboratoryResponse["rubric_uuid"])
-			c.Contains(getLaboratoryResponse["opening_date"], laboratoryOpeningDate)
-			c.Contains(getLaboratoryResponse["due_date"], laboratoryDueDate)
+			c.Equal(defaultLaboratoryOpeningDateUTC, getLaboratoryResponse["opening_date"])
+			c.Equal(defaultLaboratoryDueDateUTC, getLaboratoryResponse["due_date"])
 
 			// Validate blocks fields
 			c.Equal(0, len(getLaboratoryResponse["markdown_blocks"].([]interface{})))
@@ -135,8 +133,8 @@ func TestGetLaboratoryByUUID(t *testing.T) {
 			c.Equal(laboratoryUUID, getLaboratoryInformationResponse["uuid"])
 			c.Equal(laboratoryName, getLaboratoryInformationResponse["name"])
 			c.Nil(getLaboratoryInformationResponse["rubric_uuid"])
-			c.Contains(getLaboratoryInformationResponse["opening_date"], laboratoryOpeningDate)
-			c.Contains(getLaboratoryInformationResponse["due_date"], laboratoryDueDate)
+			c.Equal(defaultLaboratoryOpeningDateUTC, getLaboratoryInformationResponse["opening_date"])
+			c.Equal(defaultLaboratoryDueDateUTC, getLaboratoryInformationResponse["due_date"])
 		}
 	}
 }
@@ -158,14 +156,14 @@ func TestUpdateLaboratory(t *testing.T) {
 
 	// Create a laboratory
 	initialLaboratoryName := "Update laboratory test - laboratory"
-	laboratoryOpeningDate := "2023-12-01T08:00"
-	laboratoryDueDate := "2023-12-01T12:00"
+	defaultLaboratoryOpeningDate := defaultLaboratoryOpeningDate
+	defaultLaboratoryDueDate := defaultLaboratoryDueDate
 
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         initialLaboratoryName,
 		"course_uuid":  courseUUID,
-		"opening_date": laboratoryOpeningDate,
-		"due_date":     laboratoryDueDate,
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
 	c.Equal(http.StatusCreated, status)
@@ -186,8 +184,8 @@ func TestUpdateLaboratory(t *testing.T) {
 				"laboratory_uuid": "ea21f0a2-713f-427a-94d4-f541281fd654",
 				"rubric_uuid":     rubricUUID,
 				"name":            updatedLaboratoryName,
-				"opening_date":    laboratoryOpeningDate,
-				"due_date":        laboratoryDueDate,
+				"opening_date":    defaultLaboratoryOpeningDate,
+				"due_date":        defaultLaboratoryDueDate,
 			},
 			ExpectedStatusCode: http.StatusNotFound,
 		},
@@ -196,8 +194,8 @@ func TestUpdateLaboratory(t *testing.T) {
 				"laboratory_uuid": "not a uuid",
 				"rubric_uuid":     rubricUUID,
 				"name":            updatedLaboratoryName,
-				"opening_date":    laboratoryOpeningDate,
-				"due_date":        laboratoryDueDate,
+				"opening_date":    defaultLaboratoryOpeningDate,
+				"due_date":        defaultLaboratoryDueDate,
 			},
 			ExpectedStatusCode: http.StatusBadRequest,
 		},
@@ -206,8 +204,8 @@ func TestUpdateLaboratory(t *testing.T) {
 				"laboratory_uuid": laboratoryUUID,
 				"rubric_uuid":     rubricUUID,
 				"name":            updatedLaboratoryName,
-				"opening_date":    laboratoryOpeningDate,
-				"due_date":        laboratoryDueDate,
+				"opening_date":    defaultLaboratoryOpeningDate,
+				"due_date":        defaultLaboratoryDueDate,
 			},
 			ExpectedStatusCode: http.StatusNoContent,
 		},
@@ -224,8 +222,8 @@ func TestUpdateLaboratory(t *testing.T) {
 	c.Equal(http.StatusOK, status)
 	c.Equal(updatedLaboratoryName, getLaboratoryResponse["name"])
 	c.Equal(rubricUUID, getLaboratoryResponse["rubric_uuid"])
-	c.Contains(getLaboratoryResponse["opening_date"], laboratoryOpeningDate)
-	c.Contains(getLaboratoryResponse["due_date"], laboratoryDueDate)
+	c.Equal(defaultLaboratoryOpeningDateUTC, getLaboratoryResponse["opening_date"])
+	c.Equal(defaultLaboratoryDueDateUTC, getLaboratoryResponse["due_date"])
 	c.Equal(0, len(getLaboratoryResponse["markdown_blocks"].([]interface{})))
 	c.Equal(0, len(getLaboratoryResponse["test_blocks"].([]interface{})))
 }
@@ -249,8 +247,8 @@ func TestCreateMarkdownBlock(t *testing.T) {
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Create markdown block test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T12:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
 	c.Equal(http.StatusCreated, status)
@@ -319,8 +317,8 @@ func TestCreateTestBlock(t *testing.T) {
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Create test block test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T00:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
 	c.Equal(http.StatusCreated, status)
@@ -379,8 +377,8 @@ func TestGetStudentsProgress(t *testing.T) {
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Get students progress test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T00:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)
 	c.Equal(http.StatusCreated, status)

--- a/__tests__/integration/main_test.go
+++ b/__tests__/integration/main_test.go
@@ -30,6 +30,12 @@ var (
 
 	secondRegisteredTeacherEmail string
 	secondRegisteredTeacherPass  string
+
+	defaultLaboratoryOpeningDate = "2023-12-01T12:00:00-05:00"
+	defaultLaboratoryDueDate     = "3023-12-01T12:00:00-05:00"
+
+	defaultLaboratoryOpeningDateUTC = "2023-12-01T17:00:00Z"
+	defaultLaboratoryDueDateUTC     = "3023-12-01T17:00:00Z"
 )
 
 type GenericTestCase struct {

--- a/__tests__/integration/submissions_test.go
+++ b/__tests__/integration/submissions_test.go
@@ -33,8 +33,8 @@ func TestSubmitSolutionToTestBlock(t *testing.T) {
 	laboratoryCreationResponse, status := CreateLaboratory(cookie, map[string]interface{}{
 		"name":         "Submit solution to test block test - laboratory",
 		"course_uuid":  courseUUID,
-		"opening_date": "2023-12-01T08:00",
-		"due_date":     "3023-12-01T00:00",
+		"opening_date": defaultLaboratoryOpeningDate,
+		"due_date":     defaultLaboratoryDueDate,
 	})
 	c.Equal(http.StatusCreated, status)
 	laboratoryUUID := laboratoryCreationResponse["uuid"].(string)

--- a/docs/bruno/laboratories/create-laboratory.bru
+++ b/docs/bruno/laboratories/create-laboratory.bru
@@ -16,9 +16,9 @@ query {
 
 body:json {
   {
-    "course_uuid": "229e3b99-93b4-47e7-83d2-0d0471fc2261", 
+    "course_uuid": "265d7f53-caa1-40d2-bd32-c82675cb7a20", 
     "name": "Binary Tree", 
-    "opening_date": "2023-12-01T12:00", 
-    "due_date": "2024-12-02T00:00"
+    "opening_date": "2023-12-01T12:00:00-05:00", 
+    "due_date": "2024-12-01T12:00:00-05:00"
   }
 }

--- a/docs/bruno/laboratories/update-laboratory.bru
+++ b/docs/bruno/laboratories/update-laboratory.bru
@@ -13,8 +13,8 @@ put {
 body:json {
   {
     "name": "Binary Tree", 
-    "opening_date": "2023-12-01T12:00", 
-    "due_date": "2023-12-02T00:00",
+    "opening_date": "2023-12-01T12:00:00-05:00", 
+    "due_date": "2024-12-01T12:00:00-05:00",
     "rubric_uuid": null
   }
 }

--- a/sql/migrations/20230920232901_init.up.sql
+++ b/sql/migrations/20230920232901_init.up.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS rubrics (
 CREATE TABLE IF NOT EXISTS objectives (
   "id" UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   "rubric_id" UUID NOT NULL REFERENCES rubrics(id) ON DELETE CASCADE,
-  "description" VARCHAR(510) NOT NULL,
+  "description" VARCHAR(510) NOT NULL, 
   "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -71,8 +71,8 @@ CREATE TABLE IF NOT EXISTS laboratories (
   "course_id" UUID NOT NULL REFERENCES courses(id),
   "rubric_id" UUID DEFAULT NULL REFERENCES rubrics(id) ON DELETE SET DEFAULT,
   "name" VARCHAR(255) NOT NULL,
-  "opening_date" TIMESTAMP NOT NULL,
-  "due_date" TIMESTAMP NOT NULL
+  "opening_date" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "due_date" TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS blocks_index (

--- a/src/laboratories/domain/dtos/laboratories_dtos.go
+++ b/src/laboratories/domain/dtos/laboratories_dtos.go
@@ -1,13 +1,16 @@
 package dtos
 
-import "mime/multipart"
+import (
+	"mime/multipart"
+	"time"
+)
 
 type CreateLaboratoryDTO struct {
 	TeacherUUID string
 	CourseUUID  string
 	Name        string
-	OpeningDate string
-	DueDate     string
+	OpeningDate time.Time
+	DueDate     time.Time
 }
 
 type GetLaboratoryDTO struct {
@@ -21,8 +24,8 @@ type UpdateLaboratoryDTO struct {
 	TeacherUUID    string
 	RubricUUID     *string
 	Name           string
-	OpeningDate    string
-	DueDate        string
+	OpeningDate    time.Time
+	DueDate        time.Time
 }
 
 type CreateMarkdownBlockDTO struct {

--- a/src/laboratories/infrastructure/http/controllers.go
+++ b/src/laboratories/infrastructure/http/controllers.go
@@ -37,8 +37,8 @@ func (controller *LaboratoriesController) HandleCreateLaboratory(c *gin.Context)
 	}
 
 	// Validate due date is after opening date
-	openingDate, err1 := infrastructure.ParseISODate(request.OpeningDate)
-	dueDate, err2 := infrastructure.ParseISODate(request.DueDate)
+	openingDate, err1 := infrastructure.ParseRFCEDate(request.OpeningDate)
+	dueDate, err2 := infrastructure.ParseRFCEDate(request.DueDate)
 	if err1 != nil || err2 != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"message": "Invalid date format",
@@ -156,8 +156,8 @@ func (controller *LaboratoriesController) HandleUpdateLaboratory(c *gin.Context)
 	}
 
 	// Validate due date is after opening date
-	openingDate, err1 := infrastructure.ParseISODate(request.OpeningDate)
-	dueDate, err2 := infrastructure.ParseISODate(request.DueDate)
+	openingDate, err1 := infrastructure.ParseRFCEDate(request.OpeningDate)
+	dueDate, err2 := infrastructure.ParseRFCEDate(request.DueDate)
 	if err1 != nil || err2 != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"message": "Invalid date format",

--- a/src/laboratories/infrastructure/requests/laboratories_requests.go
+++ b/src/laboratories/infrastructure/requests/laboratories_requests.go
@@ -1,39 +1,49 @@
 package requests
 
-import "github.com/UPB-Code-Labs/main-api/src/laboratories/domain/dtos"
+import (
+	"time"
+
+	"github.com/UPB-Code-Labs/main-api/src/laboratories/domain/dtos"
+)
 
 type CreateLaboratoryRequest struct {
 	CourseUUID  string `json:"course_uuid" validate:"required,uuid4"`
 	Name        string `json:"name" validate:"required,min=4,max=255"`
-	OpeningDate string `json:"opening_date" validate:"required,ISO_date"`
-	DueDate     string `json:"due_date" validate:"required,ISO_date"`
+	OpeningDate string `json:"opening_date" validate:"required,RFC3339_date"`
+	DueDate     string `json:"due_date" validate:"required,RFC3339_date"`
 }
 
 func (request *CreateLaboratoryRequest) ToDTO(teacherUUID string) *dtos.CreateLaboratoryDTO {
+	parsedOpeningDate, _ := time.Parse(time.RFC3339, request.OpeningDate)
+	parsedDueDate, _ := time.Parse(time.RFC3339, request.DueDate)
+
 	return &dtos.CreateLaboratoryDTO{
 		TeacherUUID: teacherUUID,
 		CourseUUID:  request.CourseUUID,
 		Name:        request.Name,
-		OpeningDate: request.OpeningDate,
-		DueDate:     request.DueDate,
+		OpeningDate: parsedOpeningDate,
+		DueDate:     parsedDueDate,
 	}
 }
 
 type UpdateLaboratoryRequest struct {
 	Name        string  `json:"name" validate:"required,min=4,max=255"`
-	OpeningDate string  `json:"opening_date" validate:"required,ISO_date"`
-	DueDate     string  `json:"due_date" validate:"required,ISO_date"`
+	OpeningDate string  `json:"opening_date" validate:"required,RFC3339_date"`
+	DueDate     string  `json:"due_date" validate:"required,RFC3339_date"`
 	RubricUUID  *string `json:"rubric_uuid,omitempty" validate:"omitempty,uuid4"`
 }
 
 func (request *UpdateLaboratoryRequest) ToDTO(laboratoryUUID string, teacherUUID string) *dtos.UpdateLaboratoryDTO {
+	parsedOpeningDate, _ := time.Parse(time.RFC3339, request.OpeningDate)
+	parsedDueDate, _ := time.Parse(time.RFC3339, request.DueDate)
+
 	return &dtos.UpdateLaboratoryDTO{
 		TeacherUUID:    teacherUUID,
 		LaboratoryUUID: laboratoryUUID,
 		RubricUUID:     request.RubricUUID,
 		Name:           request.Name,
-		OpeningDate:    request.OpeningDate,
-		DueDate:        request.DueDate,
+		OpeningDate:    parsedOpeningDate,
+		DueDate:        parsedDueDate,
 	}
 }
 

--- a/src/shared/infrastructure/utils.go
+++ b/src/shared/infrastructure/utils.go
@@ -14,10 +14,9 @@ import (
 	"github.com/gabriel-vasile/mimetype"
 )
 
-// ParseISODate parses a date in ISO format received from a date-time input
-func ParseISODate(date string) (time.Time, error) {
-	layout := "2006-01-02T15:04"
-	return time.Parse(layout, date)
+// ParseRFCEDate parses a date in RFC3339 format
+func ParseRFCEDate(date string) (time.Time, error) {
+	return time.Parse(time.RFC3339, date)
 }
 
 // ValidateMultipartFileHeader validates the multipart archive according to the

--- a/src/shared/infrastructure/validator.go
+++ b/src/shared/infrastructure/validator.go
@@ -3,6 +3,7 @@ package infrastructure
 import (
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 )
@@ -26,9 +27,10 @@ func GetValidator() *validator.Validate {
 			return hasLetter && hasNumber && hasSpecialCharacter
 		})
 
-		validate.RegisterValidation("ISO_date", func(fl validator.FieldLevel) bool {
+		validate.RegisterValidation("RFC3339_date", func(fl validator.FieldLevel) bool {
 			date := fl.Field().String()
-			return regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$`).MatchString(date)
+			_, err := time.Parse(time.RFC3339, date)
+			return err == nil
 		})
 	}
 


### PR DESCRIPTION
## Includes 📋

Dates selected by the teacher in the UTC -5 timezone were being saved in the database as UTC, causing 5 hours of difference between the intended dates of the teacher and the actual dates saved in the database. To fix that, the following were done:  

- Add `timezone` to opening and due dates fields of laboratories in the database.
- Update requests schemas to expect the timezone of the teacher.  

## Related Issues 🔎

Closes #189 

<!-- 
## Notes 📝

Additional notes or implementation details. -->
